### PR TITLE
Implement RDM-based API's for TNQVM

### DIFF
--- a/tnqvm/tests/CMakeLists.txt
+++ b/tnqvm/tests/CMakeLists.txt
@@ -2,5 +2,7 @@
 add_xacc_test(TNQVM)
 target_link_libraries(TNQVMTester tnqvm)
 
-add_xacc_test(ExatnVisitor)
-target_link_libraries(ExatnVisitorTester tnqvm)
+if (EXATN_DIR)
+    add_xacc_test(ExatnVisitor)
+    target_link_libraries(ExatnVisitorTester tnqvm)
+endif()

--- a/tnqvm/tests/ExatnVisitorTester.cpp
+++ b/tnqvm/tests/ExatnVisitorTester.cpp
@@ -195,8 +195,8 @@ TEST(ExatnVisitorTester, testMeasurement) {
     // hence we should only get 2 results
     EXPECT_EQ(qubitReg->getMeasurementCounts().size(), 2);
     // Allow for some random variations
-    const int minCount = 0.4 * nbTrials;
-    const int maxCount = 0.6 * nbTrials;
+    const int minCount = 0.3 * nbTrials;
+    const int maxCount = 0.7 * nbTrials;
     for (const auto& resultToCount : qubitReg->getMeasurementCounts())
     {
       EXPECT_TRUE(resultToCount.first == "000" || resultToCount.first == "111");
@@ -294,6 +294,12 @@ TEST(ExatnVisitorTester, testGrover) {
   // Test Grover's algorithm
   // Amplify the amplitude of number 6 (110) state 
   const int nbTrials = 100;
+#ifdef _DEBUG
+  const bool shouldTestGroverInShotsMode = true;
+#else
+  // Disable shot simulation to save time.
+  const bool shouldTestGroverInShotsMode = false;
+#endif
 
   const auto generateGroverSrc = [](const std::string& in_name) {
     return ("__qpu__ void " + in_name).append(R"((qbit q) { 
@@ -354,6 +360,7 @@ TEST(ExatnVisitorTester, testGrover) {
     })");
   };
 
+  if (shouldTestGroverInShotsMode)
   {
     // Single-shot mode, run multiple times
     auto qpu = xacc::getAccelerator("tnqvm", {std::make_pair("tnqvm-visitor", "exatn"), std::make_pair("shots", 1)});

--- a/tnqvm/visitors/exatn/CMakeLists.txt
+++ b/tnqvm/visitors/exatn/CMakeLists.txt
@@ -52,7 +52,6 @@ if (EXATN_DIR)
       string(REGEX REPLACE " " ";" EXATN_CXX_INCLUDES "${EXATN_CXX_INCLUDES}")
       # Set compiler flags and include directories
       set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DTNQVM_HAS_EXATN ${EXATN_CXX_FLAGS}")
-      include_directories(${EXATN_CXX_INCLUDES})
    else()
       message(FATAL_ERROR "Invalid EXATN_DIR path")
    endif()
@@ -82,11 +81,12 @@ if (EXATN_DIR)
    )
 
    include_directories(${XACC_INCLUDE_DIRS})
-   include_directories(${EXATN_DIR}/include/exatn)
-   link_directories(${EXATN_DIR}/lib)
+   target_include_directories(${LIBRARY_NAME} PUBLIC ${EXATN_CXX_INCLUDES})
    # Links to ExaTN using its linker config flags.
-   target_link_libraries(${LIBRARY_NAME} ${XACC_LIBRARIES} xacc::quantum_gate lapack blas ${EXATN_CXX_LIBS})
-   
+   target_link_libraries(${LIBRARY_NAME} PUBLIC ${XACC_LIBRARIES} xacc::quantum_gate)
+   # Note: ExaTN and XACC may export common libraries(e.g. gtest), hence only link PUBLIC to XACC.
+   target_link_libraries(${LIBRARY_NAME} PRIVATE lapack blas ${EXATN_CXX_LIBS})
+
    if(APPLE)
       set_target_properties(${LIBRARY_NAME} PROPERTIES INSTALL_RPATH "@loader_path/../lib")
       set_target_properties(${LIBRARY_NAME} PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
@@ -98,7 +98,10 @@ if (EXATN_DIR)
    install(TARGETS ${LIBRARY_NAME} DESTINATION ${CMAKE_INSTALL_PREFIX}/plugins)
   
    xacc_configure_plugin_rpath(${LIBRARY_NAME})
-
+   
+   if(TNQVM_BUILD_TESTS)
+	   add_subdirectory(tests)
+   endif()
 else()
    message(STATUS "ExaTN not found, skipping ExaTNVisitor build")
 endif()

--- a/tnqvm/visitors/exatn/tests/CMakeLists.txt
+++ b/tnqvm/visitors/exatn/tests/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_xacc_test(ExatnVisitorInternal)
+target_include_directories(ExatnVisitorInternalTester PRIVATE ${CMAKE_SOURCE_DIR}/tnqvm/visitors/exatn)
+target_link_libraries(ExatnVisitorInternalTester tnqvm-exatn)

--- a/tnqvm/visitors/exatn/tests/ExatnVisitorInternalTester.cpp
+++ b/tnqvm/visitors/exatn/tests/ExatnVisitorInternalTester.cpp
@@ -1,0 +1,278 @@
+/***********************************************************************************
+ * Copyright (c) 2017, UT-Battelle
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the name of the xacc nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Contributors:
+ *   Initial API and implementation - Thien Nguyen
+ *
+ **********************************************************************************/
+#include <memory>
+#include <gtest/gtest.h>
+#include "ExatnVisitor.hpp"
+#include "xacc.hpp"
+#include "utils/GateMatrixAlgebra.hpp"
+#include <cmath>
+
+using namespace tnqvm;
+
+std::complex<double> calcMatrixTrace(const std::vector<std::complex<double>>& in_flattenedMatrix)
+{
+  const auto isPowerOfTwo = [](size_t in_number) -> bool {
+     if(in_number == 0)
+     {
+        return false; 
+     } 
+     
+     return (ceil(log2(in_number)) == floor(log2(in_number))); 
+  };
+
+  assert(isPowerOfTwo(in_flattenedMatrix.size()));
+  double dim;
+  const auto fractionalPart = std::modf(sqrt(in_flattenedMatrix.size()), &dim);
+  assert(fractionalPart == 0.0);
+  const size_t nbQubit = std::lround(dim);
+  std::complex<double> trace = 0.0;
+  for (size_t i = 0; i < nbQubit; ++i)
+  {
+    const size_t pos = i*nbQubit + i;
+    assert(pos < in_flattenedMatrix.size());
+    trace += in_flattenedMatrix[pos];
+  }
+  
+  return trace;
+}
+
+// Test ExpVal calculation:
+TEST(ExatnVisitorInternalTester, testTensorExpValCalc) {
+  // Test 1: deuteron_2 using *direct* observable for <X0X1>,
+  // i.e. no need to change basis and measure.
+  {       
+    auto xasmCompiler = xacc::getCompiler("xasm");
+    // Just the base ansatz (no measurement)
+    auto ir = xasmCompiler->compile(R"(__qpu__ void ansatz(qbit q, double t) {
+      X(q[0]);
+      Ry(q[1], t);
+      CX(q[1], q[0]);
+    })");
+
+    auto program = ir->getComposite("ansatz");
+    // Expected results from deuteron_2qbit_xasm_X0X1
+    const std::vector<double> expectedResults {
+        0.0,
+        -0.324699,
+        -0.614213,
+        -0.837166,
+        -0.9694,
+        -0.996584,
+        -0.915773,
+        -0.735724,
+        -0.475947,
+        -0.164595,
+        0.164595,
+        0.475947,
+        0.735724,
+        0.915773,
+        0.996584,
+        0.9694,
+        0.837166,
+        0.614213,
+        0.324699,
+        0.0
+    };
+     
+    const auto angles = linspace(-xacc::constants::pi, xacc::constants::pi, 20);
+    auto gateRegistry = xacc::getIRProvider("quantum");
+    auto x0 = gateRegistry->createInstruction("X", std::vector<std::size_t>{0});
+    auto x1 = gateRegistry->createInstruction("X", std::vector<std::size_t>{1});
+    // Observable term: X0X1
+    const ExatnVisitor::ObservableTerm term1({x0, x1});
+    
+    for (size_t i = 0; i < angles.size(); ++i) 
+    {
+        auto exatnVisitor = std::make_shared<ExatnVisitor>();
+        auto buffer = xacc::qalloc(2);
+        auto evaled = program->operator()({ angles[i] });
+        // Calculate the expVal
+        const auto expVal = exatnVisitor->observableExpValCalc(buffer, evaled, { term1 });
+        
+        EXPECT_NEAR(expVal.imag(), 0.0, 1e-12);
+        EXPECT_NEAR(expVal.real(), expectedResults[i], 1e-4);
+    }
+  }
+  // Test 2: Full Observable expression: multiple terms
+  {       
+    auto xasmCompiler = xacc::getCompiler("xasm");
+    // Just the base ansatz (no measurement)
+    auto ir = xasmCompiler->compile(R"(__qpu__ void ansatz1(qbit q, double t) {
+      X(q[0]);
+      Ry(q[1], t);
+      CX(q[1], q[0]);
+    })");
+
+    auto program = ir->getComposite("ansatz1");
+         
+    auto gateRegistry = xacc::getIRProvider("quantum");
+    auto x0 = gateRegistry->createInstruction("X", std::vector<std::size_t>{0});
+    auto x1 = gateRegistry->createInstruction("X", std::vector<std::size_t>{1});    
+    auto y0 = gateRegistry->createInstruction("Y", std::vector<std::size_t>{0});
+    auto y1 = gateRegistry->createInstruction("Y", std::vector<std::size_t>{1});
+    auto z0 = gateRegistry->createInstruction("Z", std::vector<std::size_t>{0});
+    auto z1 = gateRegistry->createInstruction("Z", std::vector<std::size_t>{1});
+    
+    // Observable: E = 5.907 - 2.1433 X0X1 - 2.1433 Y0Y1 + .21829 Z0 - 6.125 Z1
+    const ExatnVisitor::ObservableTerm term0({}, 5.907);
+    const ExatnVisitor::ObservableTerm term1({x0, x1}, -2.1433);
+    const ExatnVisitor::ObservableTerm term2({y0, y1}, -2.1433);
+    const ExatnVisitor::ObservableTerm term3({z0}, 0.21829);
+    const ExatnVisitor::ObservableTerm term4({z1}, -6.125);
+    // Theta -> Energy data (from VQE run using Pauli Observable)
+    std::vector<std::pair<double, double>> expectedResults = 
+    {
+      {0.0, -0.43629},
+      {1.5708, 1.62039983003},
+      {-1.5708, 10.19359983},
+      {-0.785398, 4.4527004535},
+      {0.392699, -1.59384659069},
+      {0.785398, -1.60946732175},
+      {0.981748, -1.18132079195},
+      {0.687223, -1.71581973894},
+      {0.589049, -1.74876023748},
+      {0.490874, -1.70797158239},
+      {0.539961, -1.73757413396},
+      {0.613592, -1.7474369643},
+      {0.576777, -1.74769248655},
+      {0.595185, -1.74886176773},
+      {0.60132, -1.74867505912},
+      {0.592117, -1.74884703248},
+      {0.596719, -1.74884211288},
+      {0.594418, -1.74886483954},
+      {0.593651, -1.7488634076},
+      {0.594801, -1.7488638666}
+    };
+
+    for (const auto& expectedResult : expectedResults)
+    {
+      const double theta = expectedResult.first;
+      const double energy = expectedResult.second;
+      auto exatnVisitor = std::make_shared<ExatnVisitor>();
+      auto buffer = xacc::qalloc(2);
+      auto evaled = program->operator()({ theta });
+      // Calculate the expVal
+      const auto expVal = exatnVisitor->observableExpValCalc(buffer, evaled, { term0, term1, term2, term3, term4 });
+      // The expVal is real (no imaginary part) and the real part matches the expected result.
+      EXPECT_NEAR(expVal.imag(), 0.0, 1e-12);
+      EXPECT_NEAR(expVal.real(), energy, 1e-4);
+    }   
+  }  
+}
+
+
+// Test RDM calculation: verify that the expected value calculated by RDM is consistent with regular simulation (i.e. via Measure)
+TEST(ExatnVisitorInternalTester, testReducedDensityMatrixCalc) {
+  const auto generateRandomAngle = []() -> double {
+    static std::uniform_real_distribution<double> uniformDist(-M_PI, M_PI);
+    static std::default_random_engine randomEngine;
+    return uniformDist(randomEngine);
+  };
+
+  auto xasmCompiler = xacc::getCompiler("xasm");
+  auto ir = xasmCompiler->compile(R"(__qpu__ void test1(qbit q, double theta) {
+    H(q[0]);
+    H(q[1]);
+    H(q[2]);
+    H(q[3]);
+    H(q[4]);
+    Rx(q[5], theta);
+    H(q[6]);
+    H(q[7]);
+    H(q[8]);
+    H(q[9]);
+    Measure(q[5]);
+  })");
+ 
+  const auto calcExpValByRdm = [](std::shared_ptr<CompositeInstruction>& in_function) -> double {
+    auto exatnVisitor = std::make_shared<ExatnVisitor>();
+    auto buffer = xacc::qalloc(10);
+    const auto rdm = exatnVisitor->getReducedDensityMatrix(buffer, in_function, {5});
+    {
+      // Validate trace of the RDM
+      const auto trace = calcMatrixTrace(rdm);
+      EXPECT_NEAR(trace.imag(), 0.0, 1e-12);
+      EXPECT_NEAR(trace.real(), 1.0, 1e-12);
+    }
+    // Exp-Val-Z = Rho_00 - Rho11
+    const auto expVal = rdm.front() - rdm.back();
+    EXPECT_NEAR(expVal.imag(), 0.0, 1e-12);
+    return expVal.real();
+  };
+
+  // Calculate expectation value via normal execution
+  const auto calcExpVal = [](std::shared_ptr<CompositeInstruction>& in_function) -> double {
+    auto qpu = xacc::getAccelerator("tnqvm", {std::make_pair("tnqvm-visitor", "exatn")});
+    auto qubitReg = xacc::qalloc(10);
+    qpu->execute(qubitReg, in_function);
+    return qubitReg["exp-val-z"].as<double>();
+  };
+
+  auto program = ir->getComposite("test1");
+  const size_t nbRandomTests = 1;
+  for (size_t i = 0; i < nbRandomTests; ++i)
+  {
+    const auto angle = generateRandomAngle();
+    auto evaled = program->operator()({ angle });
+    const double resultViaRdm = calcExpValByRdm(evaled);
+    const double expectedResult = calcExpVal(evaled);
+    EXPECT_NEAR(resultViaRdm, expectedResult, 1e-6);
+  }
+}
+
+// Test tensor sampling by sequential collapse -> project
+TEST(ExatnVisitorInternalTester, testSequentialCollapse) 
+{
+  auto xasmCompiler = xacc::getCompiler("xasm");
+  auto ir = xasmCompiler->compile(R"(__qpu__ void test2(qbit q) {
+    H(q[0]);
+    CNOT(q[0], q[1]);
+    CNOT(q[0], q[2]);
+    CNOT(q[0], q[3]);
+    CNOT(q[0], q[4]);
+  })");
+  auto program = ir->getComposite("test2");
+  auto exatnVisitor = std::make_shared<ExatnVisitor>();
+  auto buffer = xacc::qalloc(5);
+  // Randomly select a subset of qubits
+  const auto sampleBitString = exatnVisitor->getMeasureSample(buffer, program, { 1, 3 });
+  const bool areAllBitsEqual = std::adjacent_find(sampleBitString.cbegin(), sampleBitString.cend(), std::not_equal_to<>()) == sampleBitString.cend();
+  EXPECT_TRUE(areAllBitsEqual);
+}
+
+int main(int argc, char **argv) 
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  xacc::Initialize();
+  auto ret = RUN_ALL_TESTS();
+  xacc::Finalize();
+  return ret;
+} 


### PR DESCRIPTION
This includes:

- Calculate expectation value for an arbitrary observable.

- Calculate RDM for a subset of qubits.

- Sequential measure and collapse of tensor network.

Signed-off-by: Thien Nguyen <nguyentm@ornl.gov>