### PR TITLE
Fixes for multiple initialization of ExaTN service

### DIFF
--- a/tnqvm/visitors/exatn/ExatnActivator.cpp
+++ b/tnqvm/visitors/exatn/ExatnActivator.cpp
@@ -1,4 +1,5 @@
 #include "ExatnVisitor.hpp"
+#include "exatn.hpp"
 
 #include "OptionsProvider.hpp"
 
@@ -13,6 +14,8 @@ public:
   ExaTNActivator() {}
 
   void Start(BundleContext context) {
+    // Initialize ExaTN
+    exatn::initialize();
     auto visitor = std::make_shared<tnqvm::ExatnVisitor>();
     context.RegisterService<tnqvm::TNQVMVisitor>(visitor);
     context.RegisterService<xacc::OptionsProvider>(visitor);


### PR DESCRIPTION
Only initilize exaTN service once when TNQVM ExaTN bundle started (i.e. during XACC initialization)

Signed-off-by: Thien Nguyen <nguyentm@ornl.gov>