### PR TITLE
Fixing Exatn initialization

### DIFF
--- a/tnqvm/visitors/exatn/CMakeLists.txt
+++ b/tnqvm/visitors/exatn/CMakeLists.txt
@@ -68,7 +68,7 @@ if (ExaTN_FOUND)
    target_include_directories(${LIBRARY_NAME} PUBLIC . ..)
 
    # Links to ExaTN using its linker config flags.
-   target_link_libraries(${LIBRARY_NAME} PUBLIC xacc::xacc exatn::exatn xacc::quantum_gate tnqvm)
+   target_link_libraries(${LIBRARY_NAME} PUBLIC xacc::xacc exatn::exatn xacc::quantum_gate)
 
    if(APPLE)
       set_target_properties(${LIBRARY_NAME} PROPERTIES INSTALL_RPATH "@loader_path/../lib")

--- a/tnqvm/visitors/exatn/ExatnActivator.cpp
+++ b/tnqvm/visitors/exatn/ExatnActivator.cpp
@@ -1,5 +1,4 @@
 #include "ExatnVisitor.hpp"
-#include "exatn.hpp"
 
 #include "OptionsProvider.hpp"
 
@@ -14,8 +13,6 @@ public:
   ExaTNActivator() {}
 
   void Start(BundleContext context) {
-    // Initialize ExaTN
-    exatn::initialize();
     auto visitor = std::make_shared<tnqvm::ExatnVisitor>();
     context.RegisterService<tnqvm::TNQVMVisitor>(visitor);
     context.RegisterService<xacc::OptionsProvider>(visitor);

--- a/tnqvm/visitors/exatn/ExatnVisitor.cpp
+++ b/tnqvm/visitors/exatn/ExatnVisitor.cpp
@@ -348,8 +348,12 @@ namespace tnqvm {
     
     void ExatnVisitor::initialize(std::shared_ptr<AcceleratorBuffer> buffer, int nbShots) 
     {
-        // ExaTN should have been initialized globally when the service bundle started.
-        assert(exatn::isInitialized());
+        if(!exatn::isInitialized())
+        {
+            // If exaTN has not been initialized, do it now.
+            exatn::initialize();
+        }
+
         m_hasEvaluated = false;
         m_buffer = std::move(buffer);
         m_shots = nbShots;
@@ -464,7 +468,6 @@ namespace tnqvm {
         const auto stateVec = retrieveStateVector();
         // Re-initialize ExaTN
         resetExaTN();
-        exatn::initialize();
         // The new qubit register tensor name will have name "RESET_"
         const std::string resetTensorName = "RESET_";
         // The qubit register tensor shape is {2, 2, 2, ...}, 1 leg for each qubit


### PR DESCRIPTION
- Move the exatn::initialize() call down and wrap it in a conditional check. Also, remove a redundant call.

- Remove tnqvm from the target link list of TNQVM ExaTN.

Signed-off-by: Thien Nguyen <nguyentm@ornl.gov>