### PR TITLE
Added timing log to ExaTN visitor

### DIFF
--- a/tnqvm/visitors/TNQVMVisitor.hpp
+++ b/tnqvm/visitors/TNQVMVisitor.hpp
@@ -34,9 +34,22 @@
 #include "Identifiable.hpp"
 #include "AllGateVisitor.hpp"
 #include "xacc.hpp"
+#include <sstream>
 
 using namespace xacc;
 using namespace xacc::quantum;
+
+template <typename... Ts>
+std::string concat(Ts&&... args) {
+  std::ostringstream oss;
+  (oss << ... << std::forward<Ts>(args));
+  return oss.str();
+}
+
+// Macro to define a Telemetry zone whose execution time is tracked.
+// Using macros so that we can opt out if not need telemetry.
+#define TNQVM_TELEMETRY_ZONE(NAME, FILE, LINE) \
+  xacc::ScopeTimer __telemetry__timer(concat("tnqvm::", NAME, " (", FILE, ":", LINE, ")"));
 
 namespace tnqvm {
 class TNQVMVisitor : public AllGateVisitor, public OptionsProvider,

--- a/tnqvm/visitors/TNQVMVisitor.hpp
+++ b/tnqvm/visitors/TNQVMVisitor.hpp
@@ -49,7 +49,7 @@ std::string concat(Ts&&... args) {
 // Macro to define a Telemetry zone whose execution time is tracked.
 // Using macros so that we can opt out if not need telemetry.
 #define TNQVM_TELEMETRY_ZONE(NAME, FILE, LINE) \
-  xacc::ScopeTimer __telemetry__timer(concat("tnqvm::", NAME, " (", FILE, ":", LINE, ")"));
+  xacc::ScopeTimer __telemetry__timer(concat("tnqvm::", NAME, " (", FILE, ":", LINE, ")"), xacc::verbose);
 
 namespace tnqvm {
 class TNQVMVisitor : public AllGateVisitor, public OptionsProvider,

--- a/tnqvm/visitors/exatn-mps/ExaTnMpsVisitor.cpp
+++ b/tnqvm/visitors/exatn-mps/ExaTnMpsVisitor.cpp
@@ -253,9 +253,9 @@ void ExatnMpsVisitor::initialize(std::shared_ptr<AcceleratorBuffer> buffer, int 
         // If exaTN has not been initialized, do it now.
         exatn::initialize();
         // ExaTN and XACC logging levels are always in-synced.
-        exatn::resetRuntimeLoggingLevel(xacc::getLoggingLevel());
+        exatn::resetRuntimeLoggingLevel(xacc::verbose ? xacc::getLoggingLevel() : 0);
         xacc::subscribeLoggingLevel([](int level) {
-            exatn::resetRuntimeLoggingLevel(level);
+            exatn::resetRuntimeLoggingLevel(xacc::verbose ? level : 0);
         });
     }
 

--- a/tnqvm/visitors/exatn-mps/ExaTnMpsVisitor.cpp
+++ b/tnqvm/visitors/exatn-mps/ExaTnMpsVisitor.cpp
@@ -252,6 +252,11 @@ void ExatnMpsVisitor::initialize(std::shared_ptr<AcceleratorBuffer> buffer, int 
 
         // If exaTN has not been initialized, do it now.
         exatn::initialize();
+        // ExaTN and XACC logging levels are always in-synced.
+        exatn::resetRuntimeLoggingLevel(xacc::getLoggingLevel());
+        xacc::subscribeLoggingLevel([](int level) {
+            exatn::resetRuntimeLoggingLevel(level);
+        });
     }
 
     // Default SVD cut-off is the numerical limit, i.e. technically, no cut-off.

--- a/tnqvm/visitors/exatn-mps/RandomCircuitGen.hpp
+++ b/tnqvm/visitors/exatn-mps/RandomCircuitGen.hpp
@@ -1,6 +1,6 @@
 #pragma once
 #include "xacc.hpp"
-
+#include "xacc_service.hpp"
 #include "Circuit.hpp"
 #include "IRProvider.hpp"
 

--- a/tnqvm/visitors/exatn/ExatnVisitor.cpp
+++ b/tnqvm/visitors/exatn/ExatnVisitor.cpp
@@ -399,9 +399,10 @@ void ExatnVisitor::initialize(std::shared_ptr<AcceleratorBuffer> buffer,
     }
 
     // ExaTN and XACC logging levels are always in-synced.
-    exatn::resetRuntimeLoggingLevel(xacc::getLoggingLevel());
+    // Note: If xacc::verbose is not set, we always set ExaTN logging level to 0.
+    exatn::resetRuntimeLoggingLevel(xacc::verbose ? xacc::getLoggingLevel() : 0);
     xacc::subscribeLoggingLevel([](int level) {
-      exatn::resetRuntimeLoggingLevel(level);
+      exatn::resetRuntimeLoggingLevel(xacc::verbose ? level : 0);
     });
   }
 

--- a/tnqvm/visitors/exatn/ExatnVisitor.cpp
+++ b/tnqvm/visitors/exatn/ExatnVisitor.cpp
@@ -378,6 +378,12 @@ void ExatnVisitor::initialize(std::shared_ptr<AcceleratorBuffer> buffer,
       std::cout << "Using '" << optimizerName << "' optimizer.\n";
       exatn::resetContrSeqOptimizer(optimizerName);
     }
+
+    // ExaTN and XACC logging levels are always in-synced.
+    exatn::resetRuntimeLoggingLevel(xacc::getLoggingLevel());
+    xacc::subscribeLoggingLevel([](int level) {
+      exatn::resetRuntimeLoggingLevel(level);
+    });
   }
 
   m_hasEvaluated = false;


### PR DESCRIPTION
- The timing data is logged to console or file (depending on user configs) when `versose = true`

- ExaTN logging level is synced with that of XACC. 