### PR TITLE
Fixed TNQVM's ExaTN MPS visitor when using in VQE virtualization mode

### DIFF
--- a/tnqvm/visitors/exatn-mps/ExaTnMpsVisitor.cpp
+++ b/tnqvm/visitors/exatn-mps/ExaTnMpsVisitor.cpp
@@ -276,14 +276,17 @@ void ExatnMpsVisitor::initialize(std::shared_ptr<AcceleratorBuffer> buffer, int 
     m_qubitIdxToRank.clear();
     // Get the rank of the process    
     int process_rank = exatn::getProcessRank();
-
-    if (process_rank == 0)
+    static bool printOnce = false;
+    if (process_rank == 0 && !printOnce)
     {
-        std::cout << "============== MPI Info ============================\n";
-        std::cout << "Process " << ::getpid() << ": rank = " << process_rank << "\n";
-        std::cout << "Number of MPI processes = " << process_group.getSize() << "\n";
-        std::cout << "Memory limit per process = " << process_group.getMemoryLimitPerProcess() << "\n";
-        std::cout << "====================================================\n";
+        std::stringstream ss;
+        ss << "============== MPI Info ============================\n";
+        ss << "Process " << ::getpid() << ": rank = " << process_rank << "\n";
+        ss << "Number of MPI processes = " << process_group.getSize() << "\n";
+        ss << "Memory limit per process = " << process_group.getMemoryLimitPerProcess() << "\n";
+        ss << "====================================================\n";
+        xacc::info(ss.str());
+        printOnce = true;
     }
     m_rank = process_rank;
     // Split processes into groups:
@@ -300,8 +303,8 @@ void ExatnMpsVisitor::initialize(std::shared_ptr<AcceleratorBuffer> buffer, int 
         // the original COMMUNICATOR if we split the group w/ itself.
         m_selfProcessGroup = xacc::as_shared_ptr(&(const_cast<exatn::ProcessGroup&>(exatn::getDefaultProcessGroup())));
     }
-    std::cout << "Process [" << process_rank << "]: Number of MPI processes in sub-group = " << m_selfProcessGroup->getSize() << "\n";
-    std::cout << "Process [" << process_rank << "]: Memory limit per process in sub-group = " << m_selfProcessGroup->getMemoryLimitPerProcess() << "\n";
+    // std::cout << "Process [" << process_rank << "]: Number of MPI processes in sub-group = " << m_selfProcessGroup->getSize() << "\n";
+    // std::cout << "Process [" << process_rank << "]: Memory limit per process in sub-group = " << m_selfProcessGroup->getMemoryLimitPerProcess() << "\n";
 
     // Establish shared process groups:
     // Pairwise split
@@ -361,9 +364,9 @@ void ExatnMpsVisitor::initialize(std::shared_ptr<AcceleratorBuffer> buffer, int 
         }
     };
 
-    std::cout << "Process [" << process_rank << "]: Left group = " 
-        << processGroupToString(m_leftSharedProcessGroup) 
-        << "; Right group = " << processGroupToString(m_rightSharedProcessGroup) << "\n";
+    // std::cout << "Process [" << process_rank << "]: Left group = " 
+    //     << processGroupToString(m_leftSharedProcessGroup) 
+    //     << "; Right group = " << processGroupToString(m_rightSharedProcessGroup) << "\n";
 
     if (process_group.getSize() < m_buffer->size())
     {
@@ -380,7 +383,7 @@ void ExatnMpsVisitor::initialize(std::shared_ptr<AcceleratorBuffer> buffer, int 
         m_qubitRange = std::make_pair(process_rank, process_rank);
     }
 
-    std::cout << "Process [" << process_rank << "]: handles qubit " << m_qubitRange.first << " to " << m_qubitRange.second << "\n";  
+    // std::cout << "Process [" << process_rank << "]: handles qubit " << m_qubitRange.first << " to " << m_qubitRange.second << "\n";  
 
     if (m_buffer->size() > process_group.getSize())
     {

--- a/tnqvm/visitors/exatn-mps/NearestNeighborTransform.hpp
+++ b/tnqvm/visitors/exatn-mps/NearestNeighborTransform.hpp
@@ -26,11 +26,21 @@ public:
         }
         
         auto provider = xacc::getIRProvider("quantum");
-        auto transformedProgram = provider->createComposite(in_program->name() + "_Transformed");
-        
-        for (int i = 0; i < in_program->nInstructions(); ++i) 
+        auto flattenedProgram = provider->createComposite(in_program->name() + "_Flattened");
+        InstructionIterator it(in_program);
+        while (it.hasNext()) 
         {
-            auto inst = in_program->getInstruction(i);
+            auto nextInst = it.next();
+            if (nextInst->isEnabled() && !nextInst->isComposite()) 
+            {
+                flattenedProgram->addInstruction(nextInst->clone());
+            }
+        }
+        
+        auto transformedProgram = provider->createComposite(in_program->name() + "_Transformed");
+        for (int i = 0; i < flattenedProgram->nInstructions(); ++i) 
+        {
+            auto inst = flattenedProgram->getInstruction(i);
 
             const auto exceedMaxDistance = [&maxDistance](int q1, int q2)->bool {
                 return std::abs(q1 - q2) > maxDistance;


### PR DESCRIPTION
A couple of issues:

- Qubit tensors were not properly destroyed. Discovered during repeated execution mode of VQE.

- Removed unnecessary logging. 

- Fixed LNN circuit transformation util.: failed to handle nested Composites.