### PR TITLE
Added templated ExaTN Visitor

### DIFF
--- a/examples/sycamore/CMakeLists.txt
+++ b/examples/sycamore/CMakeLists.txt
@@ -16,3 +16,7 @@ target_compile_definitions(sycamore_circ_amplitude PRIVATE RESOURCE_DIR="${CMAKE
 add_executable(sycamore_circ_validate_contraction sycamore_circ_validate_contraction.cpp)
 target_link_libraries(sycamore_circ_validate_contraction PRIVATE xacc::xacc tnqvm)
 target_compile_definitions(sycamore_circ_validate_contraction PRIVATE RESOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/resources")
+
+add_executable(sycamore_circ_amplitude_compare sycamore_circ_amplitude_compare.cpp)
+target_link_libraries(sycamore_circ_amplitude_compare PRIVATE xacc::xacc tnqvm)
+target_compile_definitions(sycamore_circ_amplitude_compare PRIVATE RESOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/resources")

--- a/tnqvm/utils/GateMatrixAlgebra.hpp
+++ b/tnqvm/utils/GateMatrixAlgebra.hpp
@@ -123,7 +123,8 @@ void ApplyCNOTGate(StateVectorType& io_psi, size_t in_controlIndex, size_t in_ta
 	}
 }
 
-bool ApplyMeasureOp(StateVectorType& io_psi, size_t in_qubitIndex)
+template<typename ElementType>
+bool ApplyMeasureOp(std::vector<ElementType>& io_psi, size_t in_qubitIndex)
 {
     const auto N = io_psi.size();
     const auto k_range = 1ULL << in_qubitIndex;        

--- a/tnqvm/visitors/exatn/ExatnActivator.cpp
+++ b/tnqvm/visitors/exatn/ExatnActivator.cpp
@@ -14,7 +14,7 @@ public:
   ExaTNActivator() {}
 
   void Start(BundleContext context) {
-    auto visitor = std::make_shared<tnqvm::ExatnVisitor>();
+    auto visitor = std::make_shared<tnqvm::ExatnVisitor<std::complex<double>>>();
     context.RegisterService<tnqvm::TNQVMVisitor>(visitor);
     context.RegisterService<xacc::OptionsProvider>(visitor);
     // Register the ExaTN teardown service to properly finalize ExaTN.

--- a/tnqvm/visitors/exatn/ExatnActivator.cpp
+++ b/tnqvm/visitors/exatn/ExatnActivator.cpp
@@ -17,6 +17,9 @@ public:
     auto visitor = std::make_shared<tnqvm::DefaultExatnVisitor>();
     context.RegisterService<tnqvm::TNQVMVisitor>(visitor);
     context.RegisterService<xacc::OptionsProvider>(visitor);
+    // Register the alias for double and single precision visitors.
+    context.RegisterService<tnqvm::TNQVMVisitor>(std::make_shared<tnqvm::SinglePrecisionExatnVisitor>());
+    context.RegisterService<tnqvm::TNQVMVisitor>(std::make_shared<tnqvm::DoublePrecisionExatnVisitor>());
     // Register the ExaTN teardown service to properly finalize ExaTN.
     context.RegisterService<xacc::TearDown>(std::make_shared<tnqvm::ExatnTearDown>());
   }

--- a/tnqvm/visitors/exatn/ExatnActivator.cpp
+++ b/tnqvm/visitors/exatn/ExatnActivator.cpp
@@ -14,7 +14,7 @@ public:
   ExaTNActivator() {}
 
   void Start(BundleContext context) {
-    auto visitor = std::make_shared<tnqvm::ExatnVisitor<std::complex<double>>>();
+    auto visitor = std::make_shared<tnqvm::DefaultExatnVisitor>();
     context.RegisterService<tnqvm::TNQVMVisitor>(visitor);
     context.RegisterService<xacc::OptionsProvider>(visitor);
     // Register the ExaTN teardown service to properly finalize ExaTN.

--- a/tnqvm/visitors/exatn/ExatnVisitor.cpp
+++ b/tnqvm/visitors/exatn/ExatnVisitor.cpp
@@ -492,7 +492,7 @@ void ExatnVisitor<TNQVM_COMPLEX_TYPE>::initialize(std::shared_ptr<AcceleratorBuf
   // Create the qubit register tensor
   for (int i = 0; i < m_buffer->size(); ++i) {
     const bool created = exatn::createTensor(
-        generateQubitTensorName(i), exatn::TensorElementType::COMPLEX64,
+        generateQubitTensorName(i), getExatnElementType(),
         TensorShape{2});
     assert(created);
   }
@@ -612,7 +612,7 @@ void ExatnVisitor<TNQVM_COMPLEX_TYPE>::resetNetwork() {
   // The qubit register tensor shape is {2, 2, 2, ...}, 1 leg for each qubit
   std::vector<int> qubitRegResetTensorShape(m_buffer->size(), 2);
   const bool created =
-      exatn::createTensor(resetTensorName, exatn::TensorElementType::COMPLEX64,
+      exatn::createTensor(resetTensorName, getExatnElementType(),
                           qubitRegResetTensorShape);
   assert(created);
   // Initialize the tensor body with the state vector from the previous
@@ -702,14 +702,14 @@ void ExatnVisitor<TNQVM_COMPLEX_TYPE>::finalize() {
       return;
     }
 
-    const auto constructBraNetwork = [](const std::vector<int>& in_bitString){
+    const auto constructBraNetwork = [&](const std::vector<int>& in_bitString){
       int tensorIdCounter = 1;
       TensorNetwork braTensorNet("bra");
       // Create the qubit register tensor
       for (int i = 0; i < in_bitString.size(); ++i) {
         const std::string braQubitName = "QB" + std::to_string(i);
         const bool created = exatn::createTensor(
-            braQubitName, exatn::TensorElementType::COMPLEX64,
+            braQubitName, getExatnElementType(),
             TensorShape{2});
         assert(created);
         const auto bitVal = in_bitString[i];
@@ -1032,7 +1032,7 @@ void ExatnVisitor<TNQVM_COMPLEX_TYPE>::appendGateTensor(const xacc::Instruction 
                                                  : TensorShape{2, 2, 2, 2});
     // Create the tensor
     const bool created = exatn::createTensor(
-        uniqueGateName, exatn::TensorElementType::COMPLEX64, gateTensorShape);
+        uniqueGateName, getExatnElementType(), gateTensorShape);
     assert(created);
     // Init tensor body data
     exatn::initTensorData(uniqueGateName, flattenGateMatrix(gateMatrix));
@@ -1307,7 +1307,7 @@ std::vector<uint8_t> ExatnVisitor<TNQVM_COMPLEX_TYPE>::getMeasureSample(
   }
 
   std::vector<uint8_t> resultBitString;
-  std::vector<double> resultProbs;
+  std::vector<ExatnVisitor<TNQVM_COMPLEX_TYPE>::TNQVM_FLOAT_TYPE> resultProbs;
   for (const auto &qubitIdx : in_qubitIdx) {
     std::vector<TNQVM_COMPLEX_TYPE> resultRDM;
 
@@ -1339,7 +1339,7 @@ std::vector<uint8_t> ExatnVisitor<TNQVM_COMPLEX_TYPE>::getMeasureSample(
           if (resultBitString[measIdx] == 0) {
             const std::vector<TNQVM_COMPLEX_TYPE> COLLAPSE_0{
                 // Renormalize based on the probability of this outcome
-                {1.0 / resultProbs[measIdx], 0.0},
+                {1.0f / resultProbs[measIdx], 0.0},
                 {0.0, 0.0},
                 {0.0, 0.0},
                 {0.0, 0.0}};
@@ -1347,7 +1347,7 @@ std::vector<uint8_t> ExatnVisitor<TNQVM_COMPLEX_TYPE>::getMeasureSample(
             const std::string tensorName =
                 "COLLAPSE_0_" + std::to_string(measIdx);
             const bool created = exatn::createTensor(
-                tensorName, exatn::TensorElementType::COMPLEX64,
+                tensorName, getExatnElementType(),
                 TensorShape{2, 2});
             assert(created);
             const bool registered =
@@ -1366,12 +1366,12 @@ std::vector<uint8_t> ExatnVisitor<TNQVM_COMPLEX_TYPE>::getMeasureSample(
                 {0.0, 0.0},
                 {0.0, 0.0},
                 {0.0, 0.0},
-                {1.0 / resultProbs[measIdx], 0.0}};
+                {1.0f / resultProbs[measIdx], 0.0}};
 
             const std::string tensorName =
                 "COLLAPSE_1_" + std::to_string(measIdx);
             const bool created = exatn::createTensor(
-                tensorName, exatn::TensorElementType::COMPLEX64,
+                tensorName, getExatnElementType(),
                 TensorShape{2, 2});
             assert(created);
             const bool registered =
@@ -1498,7 +1498,7 @@ const double ExatnVisitor<TNQVM_COMPLEX_TYPE>::getExpectationValueZ(
 
     // The qubit register tensor shape is {2, 2, 2, ...}, 1 leg for each qubit
     std::vector<int> qubitRegResetTensorShape(m_buffer->size(), 2);
-    const bool created = exatn::createTensor(resetTensorName, exatn::TensorElementType::COMPLEX64, qubitRegResetTensorShape);
+    const bool created = exatn::createTensor(resetTensorName, getExatnElementType(), qubitRegResetTensorShape);
     assert(created);
     // Initialize the tensor body with the state vector from the previous
     // evaluation.
@@ -1563,7 +1563,7 @@ std::vector<uint8_t> ExatnVisitor<TNQVM_COMPLEX_TYPE>::generateMeasureSample(con
 {
     TNQVM_TELEMETRY_ZONE(__FUNCTION__, __FILE__, __LINE__);
     std::vector<uint8_t> resultBitString;
-    std::vector<double> resultProbs;
+    std::vector<ExatnVisitor<TNQVM_COMPLEX_TYPE>::TNQVM_FLOAT_TYPE> resultProbs;
     for (const auto& qubitIdx : in_qubitIdx)
     {
         std::vector<std::string> tensorsToDestroy;
@@ -1586,13 +1586,13 @@ std::vector<uint8_t> ExatnVisitor<TNQVM_COMPLEX_TYPE>::generateMeasureSample(con
             {
                 const std::vector<TNQVM_COMPLEX_TYPE> COLLAPSE_0{
                     // Renormalize based on the probability of this outcome
-                    {1.0 / resultProbs[measIdx], 0.0},
+                    {1.0f / resultProbs[measIdx], 0.0},
                     {0.0, 0.0},
                     {0.0, 0.0},
                     {0.0, 0.0}};
 
                 const std::string tensorName = "COLLAPSE_0_" + std::to_string(measIdx);
-                const bool created = exatn::createTensor(tensorName, exatn::TensorElementType::COMPLEX64, exatn::TensorShape{2, 2});
+                const bool created = exatn::createTensor(tensorName, getExatnElementType(), exatn::TensorShape{2, 2});
                 assert(created);
                 tensorsToDestroy.emplace_back(tensorName);
                 const bool registered = exatn::registerTensorIsometry(tensorName, {0}, {1});
@@ -1611,10 +1611,10 @@ std::vector<uint8_t> ExatnVisitor<TNQVM_COMPLEX_TYPE>::generateMeasureSample(con
                     {0.0, 0.0},
                     {0.0, 0.0},
                     {0.0, 0.0},
-                    {1.0 / resultProbs[measIdx], 0.0}};
+                    {1.0f / resultProbs[measIdx], 0.0}};
 
                 const std::string tensorName = "COLLAPSE_1_" + std::to_string(measIdx);
-                const bool created = exatn::createTensor(tensorName, exatn::TensorElementType::COMPLEX64, exatn::TensorShape{2, 2});
+                const bool created = exatn::createTensor(tensorName, getExatnElementType(), exatn::TensorShape{2, 2});
                 assert(created);
                 tensorsToDestroy.emplace_back(tensorName);
                 const bool registered = exatn::registerTensorIsometry(tensorName, {0}, {1});
@@ -1740,7 +1740,7 @@ std::vector<std::pair<double, double>> ExatnVisitor<TNQVM_COMPLEX_TYPE>::calcFlo
   // Create the collapse tensor:
   const std::vector<TNQVM_COMPLEX_TYPE> COLLAPSE_TEMP { {1.0, 0.0}, {0.0, 0.0}, {0.0, 0.0}, {0.0, 0.0} };
   const std::string tensorName = "COLLAPSE_TENSOR_TEMP";
-  const bool created = exatn::createTensor(tensorName, exatn::TensorElementType::COMPLEX64, exatn::TensorShape{2, 2});
+  const bool created = exatn::createTensor(tensorName, getExatnElementType(), exatn::TensorShape{2, 2});
   assert(created);
   const bool registered = exatn::registerTensorIsometry(tensorName, {0}, {1});
   assert(registered);

--- a/tnqvm/visitors/exatn/ExatnVisitor.cpp
+++ b/tnqvm/visitors/exatn/ExatnVisitor.cpp
@@ -766,6 +766,14 @@ void ExatnVisitor<TNQVM_COMPLEX_TYPE>::finalize() {
 
     m_buffer->addExtraInfo("amplitude-real", result.real());
     m_buffer->addExtraInfo("amplitude-imag", result.imag());
+    
+    // Destroy bra tensors
+    for (int i = 0; i < m_buffer->size(); ++i) {
+      const std::string braQubitName = "QB" + std::to_string(i);
+      const bool destroyed = exatn::destroyTensor(braQubitName);
+      assert(destroyed);
+    }
+
     m_buffer.reset();
     m_hasEvaluated = true;
     resetExaTN();

--- a/tnqvm/visitors/exatn/ExatnVisitor.hpp
+++ b/tnqvm/visitors/exatn/ExatnVisitor.hpp
@@ -195,7 +195,8 @@ namespace tnqvm {
     public:
         // Constructor
         ExatnVisitor();
-        
+        typedef typename TNQVM_COMPLEX_TYPE::value_type TNQVM_FLOAT_TYPE;
+        virtual exatn::TensorElementType getExatnElementType() const = 0;
         // Virtual function impls:        
         virtual void initialize(std::shared_ptr<AcceleratorBuffer> buffer, int nbShots) override;
         virtual void finalize() override;
@@ -204,8 +205,6 @@ namespace tnqvm {
         virtual const std::string name() const override { return "exatn"; }
 
         virtual const std::string description() const override { return "ExaTN MPS Visitor"; }
-
-        virtual std::shared_ptr<TNQVMVisitor> clone() override { return std::make_shared<ExatnVisitor>(); }
         
         virtual OptionPairs getOptions() override { /*TODO: define options */ return OptionPairs{}; }
         
@@ -331,6 +330,24 @@ namespace tnqvm {
 
     template class ExatnVisitor<std::complex<double>>;
     template class ExatnVisitor<std::complex<float>>;
+    class DoublePrecisionExatnVisitor : public ExatnVisitor<std::complex<double>>
+    {
+        virtual const std::string name() const override { return "exatn:double"; }
+        virtual exatn::TensorElementType getExatnElementType() const override { return exatn::TensorElementType::COMPLEX64; }
+        virtual std::shared_ptr<TNQVMVisitor> clone() override { return std::make_shared<DoublePrecisionExatnVisitor>(); }
+    };
+
+    class SinglePrecisionExatnVisitor : public ExatnVisitor<std::complex<float>>
+    {
+        virtual const std::string name() const override { return "exatn:float"; }
+        virtual exatn::TensorElementType getExatnElementType() const override { return exatn::TensorElementType::COMPLEX32; }
+        virtual std::shared_ptr<TNQVMVisitor> clone() override { return std::make_shared<SinglePrecisionExatnVisitor>(); }
+    };
+
+    class DefaultExatnVisitor : public DoublePrecisionExatnVisitor
+    {
+        virtual const std::string name() const override { return "exatn"; }
+    };
 } //end namespace tnqvm
 
 #endif //TNQVM_HAS_EXATN

--- a/tnqvm/visitors/exatn/tests/ExatnVisitorInternalTester.cpp
+++ b/tnqvm/visitors/exatn/tests/ExatnVisitorInternalTester.cpp
@@ -112,7 +112,7 @@ TEST(ExatnVisitorInternalTester, testTensorExpValCalc) {
 
     for (size_t i = 0; i < angles.size(); ++i)
     {
-        auto exatnVisitor = std::make_shared<ExatnVisitor<std::complex<double>>>();
+        auto exatnVisitor = std::make_shared<DefaultExatnVisitor>();
         auto buffer = xacc::qalloc(2);
         auto evaled = program->operator()({ angles[i] });
         // Calculate the expVal
@@ -177,7 +177,7 @@ TEST(ExatnVisitorInternalTester, testTensorExpValCalc) {
     {
       const double theta = expectedResult.first;
       const double energy = expectedResult.second;
-      auto exatnVisitor = std::make_shared<ExatnVisitor<std::complex<double>>>();
+      auto exatnVisitor = std::make_shared<DefaultExatnVisitor>();
       auto buffer = xacc::qalloc(2);
       auto evaled = program->operator()({ theta });
       // Calculate the expVal
@@ -214,7 +214,7 @@ TEST(ExatnVisitorInternalTester, testReducedDensityMatrixCalc) {
   })");
 
   const auto calcExpValByRdm = [](std::shared_ptr<CompositeInstruction>& in_function) -> double {
-    auto exatnVisitor = std::make_shared<ExatnVisitor<std::complex<double>>>();
+    auto exatnVisitor = std::make_shared<DefaultExatnVisitor>();
     auto buffer = xacc::qalloc(10);
     const auto rdm = exatnVisitor->getReducedDensityMatrix(buffer, in_function, {5});
     {
@@ -261,7 +261,7 @@ TEST(ExatnVisitorInternalTester, testSequentialCollapse)
     CNOT(q[0], q[4]);
   })");
   auto program = ir->getComposite("test2");
-  auto exatnVisitor = std::make_shared<ExatnVisitor<std::complex<double>>>();
+  auto exatnVisitor = std::make_shared<DefaultExatnVisitor>();
   auto buffer = xacc::qalloc(5);
   // Randomly select a subset of qubits
   const auto sampleBitString = exatnVisitor->getMeasureSample(buffer, program, { 1, 3 });

--- a/tnqvm/visitors/exatn/tests/ExatnVisitorInternalTester.cpp
+++ b/tnqvm/visitors/exatn/tests/ExatnVisitorInternalTester.cpp
@@ -108,11 +108,11 @@ TEST(ExatnVisitorInternalTester, testTensorExpValCalc) {
     auto x0 = gateRegistry->createInstruction("X", std::vector<std::size_t>{0});
     auto x1 = gateRegistry->createInstruction("X", std::vector<std::size_t>{1});
     // Observable term: X0X1
-    const ExatnVisitor::ObservableTerm term1({x0, x1});
+    const ExatnVisitor<std::complex<double>>::ObservableTerm term1({x0, x1});
 
     for (size_t i = 0; i < angles.size(); ++i)
     {
-        auto exatnVisitor = std::make_shared<ExatnVisitor>();
+        auto exatnVisitor = std::make_shared<ExatnVisitor<std::complex<double>>>();
         auto buffer = xacc::qalloc(2);
         auto evaled = program->operator()({ angles[i] });
         // Calculate the expVal
@@ -143,11 +143,11 @@ TEST(ExatnVisitorInternalTester, testTensorExpValCalc) {
     auto z1 = gateRegistry->createInstruction("Z", std::vector<std::size_t>{1});
 
     // Observable: E = 5.907 - 2.1433 X0X1 - 2.1433 Y0Y1 + .21829 Z0 - 6.125 Z1
-    const ExatnVisitor::ObservableTerm term0({}, 5.907);
-    const ExatnVisitor::ObservableTerm term1({x0, x1}, -2.1433);
-    const ExatnVisitor::ObservableTerm term2({y0, y1}, -2.1433);
-    const ExatnVisitor::ObservableTerm term3({z0}, 0.21829);
-    const ExatnVisitor::ObservableTerm term4({z1}, -6.125);
+    const ExatnVisitor<std::complex<double>>::ObservableTerm term0({}, 5.907);
+    const ExatnVisitor<std::complex<double>>::ObservableTerm term1({x0, x1}, -2.1433);
+    const ExatnVisitor<std::complex<double>>::ObservableTerm term2({y0, y1}, -2.1433);
+    const ExatnVisitor<std::complex<double>>::ObservableTerm term3({z0}, 0.21829);
+    const ExatnVisitor<std::complex<double>>::ObservableTerm term4({z1}, -6.125);
     // Theta -> Energy data (from VQE run using Pauli Observable)
     std::vector<std::pair<double, double>> expectedResults =
     {
@@ -177,7 +177,7 @@ TEST(ExatnVisitorInternalTester, testTensorExpValCalc) {
     {
       const double theta = expectedResult.first;
       const double energy = expectedResult.second;
-      auto exatnVisitor = std::make_shared<ExatnVisitor>();
+      auto exatnVisitor = std::make_shared<ExatnVisitor<std::complex<double>>>();
       auto buffer = xacc::qalloc(2);
       auto evaled = program->operator()({ theta });
       // Calculate the expVal
@@ -214,7 +214,7 @@ TEST(ExatnVisitorInternalTester, testReducedDensityMatrixCalc) {
   })");
 
   const auto calcExpValByRdm = [](std::shared_ptr<CompositeInstruction>& in_function) -> double {
-    auto exatnVisitor = std::make_shared<ExatnVisitor>();
+    auto exatnVisitor = std::make_shared<ExatnVisitor<std::complex<double>>>();
     auto buffer = xacc::qalloc(10);
     const auto rdm = exatnVisitor->getReducedDensityMatrix(buffer, in_function, {5});
     {
@@ -261,7 +261,7 @@ TEST(ExatnVisitorInternalTester, testSequentialCollapse)
     CNOT(q[0], q[4]);
   })");
   auto program = ir->getComposite("test2");
-  auto exatnVisitor = std::make_shared<ExatnVisitor>();
+  auto exatnVisitor = std::make_shared<ExatnVisitor<std::complex<double>>>();
   auto buffer = xacc::qalloc(5);
   // Randomly select a subset of qubits
   const auto sampleBitString = exatnVisitor->getMeasureSample(buffer, program, { 1, 3 });


### PR DESCRIPTION
Now, we have the ability to specify the tensor element type of either `std::complex<double>` or `std::complex<float>`.

Use the `:` suffix to distinguish between them, i.e. `exatn:double` and `exatn:float`.

Default (`exatn`) visitor uses `std::complex<double>` type to be consistent with the current behavior. 