### PR TITLE
Added docs to the headers and link to XACC's readthedocs

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(multiple_visitors)
 add_subdirectory(sycamore)
 add_subdirectory(mpi)
+add_subdirectory(base_api)

--- a/examples/base_api/CMakeLists.txt
+++ b/examples/base_api/CMakeLists.txt
@@ -1,0 +1,11 @@
+include_directories(${XACC_INCLUDE_DIRS})
+include_directories(${PROJECT_SOURCE_DIR})
+
+add_executable(qasm_sim qasm_sim.cpp)
+target_link_libraries(qasm_sim PRIVATE xacc::xacc)
+
+add_executable(bitstring_amplitude bitstring_amplitude.cpp)
+target_link_libraries(bitstring_amplitude PRIVATE xacc::xacc)
+
+add_executable(noisy_sim noisy_sim.cpp)
+target_link_libraries(noisy_sim PRIVATE xacc::xacc)

--- a/examples/base_api/bitstring_amplitude.cpp
+++ b/examples/base_api/bitstring_amplitude.cpp
@@ -1,0 +1,78 @@
+/***********************************************************************************
+ * Copyright (c) 2020, UT-Battelle
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the name of the xacc nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Contributors:
+ *   Initial implementation - Thien Nguyen
+ *
+ **********************************************************************************/
+
+// This example demonstrates bitstring amplitude calculation API.
+#include "xacc.hpp"
+
+int main(int argc, char **argv) {
+
+  // Initialize the XACC Framework
+  xacc::Initialize(argc, argv);
+
+  // Allocate a register of 50 qubits
+  // Note: since we only compute the amplitude of a single output state,
+  // we can handle many qubits.
+  auto qubitReg = xacc::qalloc(50);
+
+  // Output state: all ones's
+  const std::vector<int> bitstring(50, 1);
+  // Using the ExaTN backend:
+  // specify the bitstring to compute the amplitude.
+  auto qpu = xacc::getAccelerator("tnqvm", {
+                                               {"tnqvm-visitor", "exatn"},
+                                               {"bitstring", bitstring},
+                                           });
+  // Create a Program: creare an entangled state:
+  // |00000..00> + |11111....11>
+  auto xasmCompiler = xacc::getCompiler("xasm");
+  auto ir = xasmCompiler->compile(R"(__qpu__ void test(qbit q, double theta) {
+    H(q[0]);
+    for (int i = 1; i < 50; i++) {
+      CX(q[0], q[i]); 
+    }
+  })",
+                                  qpu);
+
+  // Request the quantum kernel representing
+  // the above source code
+  auto program = ir->getComposite("test");
+  // Execute!
+  qpu->execute(qubitReg, program);
+  // Print the result in the buffer:
+  // i.e. the amplitude of the |1111..111> output state.
+  // Expected = 1/sqrt(2) = 0.707
+  qubitReg->print();
+
+  // Finalize the XACC Framework
+  xacc::Finalize();
+
+  return 0;
+}

--- a/examples/base_api/noisy_sim.cpp
+++ b/examples/base_api/noisy_sim.cpp
@@ -1,0 +1,74 @@
+/***********************************************************************************
+ * Copyright (c) 2020, UT-Battelle
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the name of the xacc nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Contributors:
+ *   Initial implementation - Thien Nguyen
+ *
+ **********************************************************************************/
+
+// This example demonstrates the basic usage of TNQVM's exatn visitor for QASM
+// circuit simulation.
+#include "xacc.hpp"
+
+int main(int argc, char **argv) {
+
+  // Initialize the XACC Framework
+  xacc::Initialize(argc, argv);
+
+  // Using the purified-mps backend with noise model from
+  // "ibmq_5_yorktown - ibmqx2" device.
+  // **IMPORTANT** make sure you have a valid IBMQ credential stored in
+  // ~/.ibm_config file.
+  auto qpu = xacc::getAccelerator(
+      "tnqvm", {{"tnqvm-visitor", "exatn-pmps"}, {"backend", "ibmqx2"}});
+
+  // Allocate a register of 2 qubits
+  auto qubitReg = xacc::qalloc(2);
+
+  // Create a Program: simple Bell test
+  auto xasmCompiler = xacc::getCompiler("xasm");
+  auto ir = xasmCompiler->compile(R"(__qpu__ void test(qbit q, double theta) {
+    H(q[0]);
+    CX(q[0],q[1]);
+    Measure(q[0]);
+    Measure(q[1]);
+    })",
+                                  qpu);
+
+  // Request the quantum kernel representing
+  // the above source code
+  auto program = ir->getComposite("test");
+
+  // Execute!
+  qpu->execute(qubitReg, program);
+  // Print the result (measurement count distribution) in the buffer.
+  qubitReg->print();
+
+  // Finalize the XACC Framework
+  xacc::Finalize();
+
+  return 0;
+}

--- a/examples/base_api/qasm_sim.cpp
+++ b/examples/base_api/qasm_sim.cpp
@@ -1,0 +1,74 @@
+/***********************************************************************************
+ * Copyright (c) 2020, UT-Battelle
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the name of the xacc nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Contributors:
+ *   Initial implementation - Thien Nguyen
+ *
+ **********************************************************************************/
+
+// This example demonstrates the basic usage of TNQVM's exatn visitor for QASM
+// circuit simulation.
+#include "xacc.hpp"
+
+int main(int argc, char **argv) {
+
+  // Initialize the XACC Framework
+  xacc::Initialize(argc, argv);
+
+  // Using the ExaTN backend
+  auto qpu = xacc::getAccelerator("tnqvm", {{"tnqvm-visitor", "exatn"}});
+
+  // Allocate a register of 2 qubits
+  auto qubitReg = xacc::qalloc(2);
+
+  // Create a Program
+  auto xasmCompiler = xacc::getCompiler("xasm");
+  auto ir = xasmCompiler->compile(R"(__qpu__ void test(qbit q, double theta) {
+      H(q[0]);
+      CX(q[0], q[1]);
+	  Rx(q[0], theta);
+	  Ry(q[1], theta);
+	  H(q[1]);
+	  CX(q[1], q[0]);
+      Measure(q[0]);
+    })",
+                                  qpu);
+
+  // Request the quantum kernel representing
+  // the above source code
+  auto program = ir->getComposite("test");
+  const auto rotationAngle = M_PI / 3.0;
+  auto evaled = program->operator()({rotationAngle});
+  // Execute!
+  qpu->execute(qubitReg, evaled);
+  // Print the result in the buffer.
+  qubitReg->print();
+
+  // Finalize the XACC Framework
+  xacc::Finalize();
+
+  return 0;
+}

--- a/tnqvm/TNQVM.hpp
+++ b/tnqvm/TNQVM.hpp
@@ -36,6 +36,8 @@
 #include "TNQVMVisitor.hpp"
 #include <cassert>
 
+// Documentation: https://xacc.readthedocs.io/en/latest/extensions.html#tnqvm
+
 namespace tnqvm {
 
 class TNQVM : public Accelerator {

--- a/tnqvm/visitors/exatn-mpo/ExaTnPmpsVisitor.hpp
+++ b/tnqvm/visitors/exatn-mpo/ExaTnPmpsVisitor.hpp
@@ -4,6 +4,18 @@
 #include "tensor_network.hpp"
 #include "exatn.hpp"
 
+// Purified-MPS visitor:
+// Name: "exatn-pmps"
+// Supported initialization keys:
+// +-----------------------------+------------------------------------------------------------------------+-------------+--------------------------+
+// |  Initialization Parameter   |                  Parameter Description                                 |    type     |         default          |
+// +=============================+========================================================================+=============+==========================+
+// | backend-json                | Backend configuration JSON to estimate the noise model from.           |    string   | None                     |
+// +-----------------------------+------------------------------------------------------------------------+-------------+--------------------------+
+// | backend                     | Name of the IBMQ backend to query the backend configuration.           |    string   | None                     |
+// +-----------------------------+------------------------------------------------------------------------+-------------+--------------------------+
+// If either `backend-json` or `backend` is provided, the `exatn-pmps` simulator will simulate the backend noise associated with each quantum gate.
+
 namespace xacc {
 // Forward declaration
 class NoiseModel;

--- a/tnqvm/visitors/exatn-mps/ExaTnMpsVisitor.hpp
+++ b/tnqvm/visitors/exatn-mps/ExaTnMpsVisitor.hpp
@@ -4,6 +4,20 @@
 #include "GateTensorAggregator.hpp"
 #include "tensor_network.hpp"
 
+// MPS visitor:
+// Name: "exatn-mps"
+// Supported initialization keys:
+// +-----------------------------+------------------------------------------------------------------------+-------------+--------------------------+
+// |  Initialization Parameter   |                  Parameter Description                                 |    type     |         default          |
+// +=============================+========================================================================+=============+==========================+
+// | svd-cutoff                  | SVD cut-off limit.                                                     |    double   | numeric_limits::min      |
+// +-----------------------------+------------------------------------------------------------------------+-------------+--------------------------+
+// | max-bond-dim                | Max bond dimension to keep.                                            |    int      | no limit                 |
+// +-----------------------------+------------------------------------------------------------------------+-------------+--------------------------+
+// | mpi-communicator            | The MPI communicator to initialize ExaTN runtime with.                 |    void*    | <unused>                 |
+// |                             | If not provided, by default, ExaTN will use `MPI_COMM_WORLD`.          |             |                          |
+// +-----------------------------+------------------------------------------------------------------------+-------------+--------------------------+
+
 namespace tnqvm {
 class ExatnMpsVisitor : public TNQVMVisitor, public IAggregatorListener
 {

--- a/tnqvm/visitors/exatn/ExatnVisitor.hpp
+++ b/tnqvm/visitors/exatn/ExatnVisitor.hpp
@@ -44,6 +44,42 @@ using namespace xacc;
 using namespace xacc::quantum;
 using TensorFunctor = talsh::TensorFunctor<exatn::Identifiable>;
 
+// Full tensor network contraction visitor:
+// Name: "exatn"
+// Tensor element floating-point precision (float/double) can be specified using:
+// "exatn:float" or "exatn:double"
+// Default is *double* if not provided.
+// Supported initialization keys:
+// +-----------------------------+------------------------------------------------------------------------+-------------+--------------------------+
+// |  Initialization Parameter   |                  Parameter Description                                 |    type     |         default          |
+// +=============================+========================================================================+=============+==========================+
+// | exatn-buffer-size-gb        | ExaTN's host memory buffer size (in GB)                                |    int      | 8 (GB)                   |
+// +-----------------------------+------------------------------------------------------------------------+-------------+--------------------------+
+// | exatn-contract-seq-optimizer| ExaTN's contraction sequence optimizer to use.                         |    string   | metis                    |
+// +-----------------------------+------------------------------------------------------------------------+-------------+--------------------------+
+// | calc-contract-cost-flops    | Estimate the Flops and Memory requirements only (no tensor contraction)|    bool     | false                    |
+// |                             | If true, the following info will be added to the AcceleratorBuffer:    |             |                          |
+// |                             | - `contract-flops`: Flops count.                                       |             |                          |
+// |                             | - `max-node-bytes`: Max intermediate tensor size in memory.            |             |                          |
+// |                             | - `optimizer-elapsed-time-ms`: optimization walltime.                  |             |                          |
+// +-----------------------------+------------------------------------------------------------------------+-------------+--------------------------+
+// | bitstring                   | If provided, the output amplitude/partial state vector associated with | vector<int> | <unused>                 |
+// |                             | that `bitstring` will be computed.                                     |             |                          |
+// |                             | The length of the input `bitstring` must match the number of qubits.   |             |                          |
+// |                             | Non-projected bits (partial state vector) are indicated by `-1` values.|             |                          |
+// |                             | Returned values in the AcceleratorBuffer:                              |             |                          |
+// |                             | - `amplitude-real`/`amplitude-real-vec`: Real part of the result.      |             |                          |
+// |                             | - `amplitude-imag`/`amplitude-imag-vec`: Imaginary part of the result. |             |                          |
+// +-----------------------------+------------------------------------------------------------------------+-------------+--------------------------+
+// | contract-with-conjugate     | If true, we append the conjugate of the input circuit.                 |    bool     | false                    |
+// |                             | This is used to validate internal tensor contraction.                  |             |                          |
+// |                             | `contract-with-conjugate-result` key in the AcceleratorBuffer will be  |             |                          |
+// |                             | set to `true` if the validation is successful.                         |             |                          |
+// +-----------------------------+------------------------------------------------------------------------+-------------+--------------------------+
+// | mpi-communicator            | The MPI communicator to initialize ExaTN runtime with.                 |    void*    | <unused>                 |
+// |                             | If not provided, by default, ExaTN will use `MPI_COMM_WORLD`.          |             |                          |
+// +-----------------------------+------------------------------------------------------------------------+-------------+--------------------------+
+
 namespace tnqvm {
     // Simple struct to identify a concrete quantum gate instance,
     // For example, parametric gates, e.g. Rx(theta), will have an instance for each value of theta


### PR DESCRIPTION
- Added the list of supported configuration keys to each visitor header file.

- Added link to the updated XACC readthedocs.

- Added new examples demonstrating TNQVM usage.


Signed-off-by: Thien Nguyen <nguyentm@ornl.gov>