### PR TITLE
Fixed a bug when refactoring wavefunc slicing into helper function

### DIFF
--- a/tnqvm/visitors/exatn/ExatnVisitor.cpp
+++ b/tnqvm/visitors/exatn/ExatnVisitor.cpp
@@ -732,7 +732,7 @@ void ExatnVisitor<TNQVM_COMPLEX_TYPE>::finalize() {
     if (waveFuncSlice.size() == 1)
     {
       m_buffer->addExtraInfo("amplitude-real", waveFuncSlice[0].real());
-      m_buffer->addExtraInfo("amplitude-imag", waveFuncSlice[1].imag());
+      m_buffer->addExtraInfo("amplitude-imag", waveFuncSlice[0].imag());
     }
     else
     {


### PR DESCRIPTION
The single amplitude was returned in an one-element vector. I accidentally use an invalid index to get the imaginary part.

Signed-off-by: Thien Nguyen <nguyentm@ornl.gov>