### PR TITLE
Fixes for https://github.com/ORNL-QCI/tnqvm/issues/89

### DIFF
--- a/tnqvm/base/Gates.hpp
+++ b/tnqvm/base/Gates.hpp
@@ -221,6 +221,19 @@ namespace tnqvm {
         };    
     }
 
+    template <>
+    std::vector<std::vector<std::complex<double>>>
+    GetGateMatrix<CommonGates::U>(double in_theta, double in_phi,
+                                  double in_lambda) {
+      return {
+          {std::cos(in_theta / 2.0),
+           -std::exp(std::complex<double>(0, in_lambda)) *
+               std::sin(in_theta / 2.0)},
+          {std::exp(std::complex<double>(0, in_phi)) * std::sin(in_theta / 2.0),
+           std::exp(std::complex<double>(0, in_phi + in_lambda)) *
+               std::cos(in_theta / 2.0)}};
+    }
+
     template <> 
     std::vector<std::vector<std::complex<double>>> GetGateMatrix<CommonGates::CNOT>() {
         return 

--- a/tnqvm/visitors/exatn-dm/ExaTnDmVisitor.cpp
+++ b/tnqvm/visitors/exatn-dm/ExaTnDmVisitor.cpp
@@ -143,6 +143,11 @@ getGateMatrix(const xacc::Instruction &in_gate, bool in_dagger = false) {
     case CommonGates::Rz:
       return GetGateMatrix<CommonGates::Rz>(
           in_gate.getParameter(0).as<double>());
+    case CommonGates::U:
+      return GetGateMatrix<CommonGates::U>(
+          in_gate.getParameter(0).as<double>(),
+          in_gate.getParameter(1).as<double>(),
+          in_gate.getParameter(2).as<double>());
     case CommonGates::I:
       return GetGateMatrix<CommonGates::I>();
     case CommonGates::H:

--- a/tnqvm/visitors/exatn-mpo/ExaTnPmpsVisitor.cpp
+++ b/tnqvm/visitors/exatn-mpo/ExaTnPmpsVisitor.cpp
@@ -154,8 +154,15 @@ std::vector<std::complex<double>> getGateMatrix(const xacc::Instruction& in_gate
             case CommonGates::X: return GetGateMatrix<CommonGates::X>();
             case CommonGates::Y: return GetGateMatrix<CommonGates::Y>();
             case CommonGates::Z: return GetGateMatrix<CommonGates::Z>();
-            case CommonGates::T: return GetGateMatrix<CommonGates::T>();
-            case CommonGates::Tdg: return GetGateMatrix<CommonGates::Tdg>();
+            case CommonGates::T:
+              return GetGateMatrix<CommonGates::T>();
+            case CommonGates::U:
+              return GetGateMatrix<CommonGates::U>(
+                  in_gate.getParameter(0).as<double>(),
+                  in_gate.getParameter(1).as<double>(),
+                  in_gate.getParameter(2).as<double>());
+            case CommonGates::Tdg:
+              return GetGateMatrix<CommonGates::Tdg>();
             case CommonGates::CNOT: return GetGateMatrix<CommonGates::CNOT>();
             case CommonGates::Swap: return GetGateMatrix<CommonGates::Swap>();
             case CommonGates::iSwap: return GetGateMatrix<CommonGates::iSwap>();

--- a/tnqvm/visitors/exatn-mps/ExatnUtils.cpp
+++ b/tnqvm/visitors/exatn-mps/ExatnUtils.cpp
@@ -56,8 +56,15 @@ GateTensor GateTensorConstructor::getGateTensor(xacc::Instruction& in_gate)
             case CommonGates::Y: return GetGateMatrix<CommonGates::Y>();
             case CommonGates::Z: return GetGateMatrix<CommonGates::Z>();
             case CommonGates::T: return GetGateMatrix<CommonGates::T>();
-            case CommonGates::Tdg: return GetGateMatrix<CommonGates::Tdg>();
-            case CommonGates::CNOT: return GetGateMatrix<CommonGates::CNOT>();
+            case CommonGates::Tdg:
+              return GetGateMatrix<CommonGates::Tdg>();
+            case CommonGates::U:
+              return GetGateMatrix<CommonGates::U>(
+                  in_gate.getParameter(0).as<double>(),
+                  in_gate.getParameter(1).as<double>(),
+                  in_gate.getParameter(2).as<double>());
+            case CommonGates::CNOT:
+              return GetGateMatrix<CommonGates::CNOT>();
             case CommonGates::Swap: return GetGateMatrix<CommonGates::Swap>();
             case CommonGates::iSwap: return GetGateMatrix<CommonGates::iSwap>();
             case CommonGates::fSim: return GetGateMatrix<CommonGates::fSim>(in_gate.getParameter(0).as<double>(), in_gate.getParameter(1).as<double>());

--- a/tnqvm/visitors/exatn/ExatnVisitor.cpp
+++ b/tnqvm/visitors/exatn/ExatnVisitor.cpp
@@ -924,7 +924,11 @@ void ExatnVisitor<TNQVM_COMPLEX_TYPE>::visit(CPhase &in_CPhaseGate) {
 template<typename TNQVM_COMPLEX_TYPE>
 void ExatnVisitor<TNQVM_COMPLEX_TYPE>::visit(U &in_UGate) {
   TNQVM_TELEMETRY_ZONE(__FUNCTION__, __FILE__, __LINE__);
-  appendGateTensor<CommonGates::U>(in_UGate);
+  assert(in_UGate.nParameters() == 3);
+  const double theta = in_UGate.getParameter(0).as<double>();
+  const double phi = in_UGate.getParameter(1).as<double>();
+  const double lambda = in_UGate.getParameter(2).as<double>();
+  appendGateTensor<CommonGates::U>(in_UGate, theta, phi, lambda);
 }
 
 template<typename TNQVM_COMPLEX_TYPE>


### PR DESCRIPTION
The test script is using ITensor-based visitor and the U3 impl. is not accurate. Hence, fixed by using the direct matrix form of U3 (should be faster).

Also, it turns out I didn't forward U3 parameters to exatn-based visitors as well. Fixed accordingly.

Tested by: running the Python test case and comparing the result w/ qpp.

Signed-off-by: Thien Nguyen <nguyentm@ornl.gov>