### PR TITLE
Fixed exp-val calculation by slicing and conjugate

### DIFF
--- a/python/examples/exp-val-calc.py
+++ b/python/examples/exp-val-calc.py
@@ -1,0 +1,47 @@
+import sys
+from pathlib import Path
+sys.path.insert(1, str(Path.home()) + '/.xacc')
+import xacc
+xacc.qasm('''
+.compiler xasm
+.circuit ansatz
+.qbit q
+U(q[1], 1.5708,0,3.14159);
+U(q[0], 1.5708,1.5708,4.71239); 
+CNOT(q[0], q[1]);
+U(q[2], 1.5708,-3.14159,3.14159); 
+U(q[3], 1.5708,0,3.14159); 
+CNOT(q[2], q[3]);
+Rz(q[3], 0.101476); 
+CNOT(q[2], q[3]);
+CNOT(q[1], q[2]);
+CNOT(q[0], q[1]);
+U(q[3], 1.5708,0,3.14159); 
+U(q[2], 1.5708,0,3.14159); 
+U(q[0], 1.5708,1.5708,4.71239); 
+U(q[1], 1.5708,0,3.14159); 
+''')
+ansatz = xacc.getCompiled('ansatz')
+#qpu = xacc.getAccelerator('qsim')
+qpu = xacc.getAccelerator('tnqvm:exatn', {"exp-val-by-conjugate": True, "max-qubit": 2})
+print("QPU:", qpu.name())
+buffer = xacc.qalloc(4)
+geom = '''
+Na  0.000000   0.0      0.0
+H   0.0        0.0  1.914388
+'''
+fo = [0, 1, 2, 3, 4, 10, 11, 12, 13, 14]
+ao = [5, 9, 15, 19]
+H = xacc.getObservable('pyscf', {'basis': 'sto-3g', 'geometry': geom,
+                                       'frozen-spin-orbitals': fo, 'active-spin-orbitals': ao})
+# print(H.toString())
+opt = xacc.getOptimizer('nlopt')
+vqe = xacc.getAlgorithm('vqe', {
+                        'ansatz': ansatz,
+                        'accelerator': qpu,
+                        'observable': H,
+                        'optimizer': opt
+                        })
+# # xacc.set_verbose(True)
+energy = vqe.execute(buffer, [])
+print('Energy = ', energy)

--- a/tnqvm/tests/ExatnExpValSumReduceTester.cpp
+++ b/tnqvm/tests/ExatnExpValSumReduceTester.cpp
@@ -115,6 +115,11 @@ TEST(ExatnExpValSumReduceTester, testSliceOfMultipleQubits) {
   auto buffer = xacc::qalloc(4);
   accelerator->execute(buffer, program);
   buffer->print();
+  // Validate with QPP
+  auto qpp = xacc::getAccelerator("qpp");
+  auto buffer_qpp = xacc::qalloc(4);
+  qpp->execute(buffer_qpp, program);
+  EXPECT_NEAR(buffer->getExpectationValueZ(), buffer_qpp->getExpectationValueZ(), 1e-6);
 }
 
 TEST(ExatnExpValSumReduceTester, testDeuteronH3) {

--- a/tnqvm/tests/ExatnExpValSumReduceTester.cpp
+++ b/tnqvm/tests/ExatnExpValSumReduceTester.cpp
@@ -80,6 +80,43 @@ TEST(ExatnExpValSumReduceTester, testDeuteron) {
   }
 }
 
+TEST(ExatnExpValSumReduceTester, testSliceOfMultipleQubits) {
+  auto accelerator = xacc::getAccelerator(
+      "tnqvm", {{"tnqvm-visitor", "exatn"}, {"max-qubit", 2}});
+  xacc::qasm(R"(
+        .compiler xasm
+        .circuit test_circuit
+        .qbit q
+        U(q[1], 1.5708,0,3.14159);
+        U(q[0], 1.5708,1.5708,4.71239); 
+        CNOT(q[0], q[1]);
+        U(q[2], 1.5708,-3.14159,3.14159); 
+        U(q[3], 1.5708,0,3.14159); 
+        CNOT(q[2], q[3]);
+        Rz(q[3], 0.101476); 
+        CNOT(q[2], q[3]);
+        CNOT(q[1], q[2]);
+        CNOT(q[0], q[1]);
+        U(q[3], 1.5708,0,3.14159); 
+        U(q[2], 1.5708,0,3.14159); 
+        U(q[0], 1.5708,1.5708,4.71239); 
+        U(q[1], 1.5708,0,3.14159); 
+        H(q[0]);
+        H(q[1]);
+        H(q[2]);
+        H(q[3]);
+        Measure(q[0]);
+        Measure(q[1]);
+        Measure(q[2]);
+        Measure(q[3]);
+    )");
+
+  auto program = xacc::getCompiled("test_circuit");
+  auto buffer = xacc::qalloc(4);
+  accelerator->execute(buffer, program);
+  buffer->print();
+}
+
 TEST(ExatnExpValSumReduceTester, testDeuteronH3) {
   auto accelerator = xacc::getAccelerator(
       "tnqvm", {{"tnqvm-visitor", "exatn"}, {"max-qubit", 2}});

--- a/tnqvm/visitors/exatn/ExatnVisitor.cpp
+++ b/tnqvm/visitors/exatn/ExatnVisitor.cpp
@@ -1765,6 +1765,8 @@ ExatnVisitor<TNQVM_COMPLEX_TYPE>::getExpectationValueZByAppendingConjugate(
     std::shared_ptr<CompositeInstruction> in_function) {
   // Cache the current tensor network:
   exatn::TensorNetwork cacheTensorNet = m_tensorNetwork;
+  const auto cachedIdCounter = m_tensorIdCounter;
+  auto cachedTensorList = m_appendedGateTensors;
   InstructionIterator it(in_function);
   // Add remaining instructions:
   while (it.hasNext()) {
@@ -1778,6 +1780,8 @@ ExatnVisitor<TNQVM_COMPLEX_TYPE>::getExpectationValueZByAppendingConjugate(
   m_measureQbIdx.clear();
   // Restore the base tensor network
   m_tensorNetwork = cacheTensorNet;
+  m_tensorIdCounter = cachedIdCounter;
+  m_appendedGateTensors = cachedTensorList;
   return result;
 }
 

--- a/tnqvm/visitors/exatn/ExatnVisitor.cpp
+++ b/tnqvm/visitors/exatn/ExatnVisitor.cpp
@@ -1618,8 +1618,8 @@ double ExatnVisitor<TNQVM_COMPLEX_TYPE>::getExpectationValueZBySlicing() {
   // Loop to be parallelized
   if (getNumMpiProcs() <= 1) {
     std::vector<double> partialExpectationValues(nbProjectedPaths);
-    bool evenParity = true;
     for (int i = 0; i < nbProjectedPaths; ++i) {
+      bool evenParity = true;
       // Open legs: 0-m_maxQubit
       std::vector<int> bitString(m_maxQubit, -1);
       for (int64_t bitIdx = 0; bitIdx < nbProjectedQubits; ++bitIdx) {
@@ -1681,9 +1681,9 @@ double ExatnVisitor<TNQVM_COMPLEX_TYPE>::getExpectationValueZBySlicing() {
                 << "]: Start = " << processStartIdx
                 << "; End = " << processEndIdx << "\n";
       xacc::info(ss.str());
-      bool evenParity = true;
       int64_t vectorIdx = 0;
       for (int64_t i = processStartIdx; i < processEndIdx; ++i) {
+        bool evenParity = true;
         // Open legs: 0-m_maxQubit
         std::vector<int> bitString(m_maxQubit, -1);
         for (int64_t bitIdx = 0; bitIdx < nbProjectedQubits; ++bitIdx) {


### PR DESCRIPTION
The test circuit in https://github.com/ORNL-QCI/tnqvm/issues/91 helped uncover some subtle bugs in these special exp-val calculation methods.

- In the slicing method, the parity tracker flag was not placed in the correct scope -> not properly initialized.

-  In the double-depth method, the counter and tensor name list must be cached for the base circuit, before adding change-of-basis.