### PR TITLE
Allow bitstring amplitude calculation for small circuits as well (MPS)

### DIFF
--- a/tnqvm/visitors/exatn-mps/ExaTnMpsVisitor.cpp
+++ b/tnqvm/visitors/exatn-mps/ExaTnMpsVisitor.cpp
@@ -649,7 +649,7 @@ void ExatnMpsVisitor::finalize()
 
         // const auto stateVecNorm = computeStateVectorNorm(*m_tensorNetwork, exatn::getCurrentProcessGroup());
         // Small-circuit case: just reconstruct the full wavefunction
-        if (m_buffer->size() < MAX_NUMBER_QUBITS_FOR_STATE_VEC) 
+        if (m_buffer->size() < MAX_NUMBER_QUBITS_FOR_STATE_VEC && !options.keyExists<std::vector<int>>("bitstring")) 
         {
             // DEBUG:
             // printStateVec();


### PR DESCRIPTION
Previously, we only has this for large circuit. Making it consistent w/ exatn visitor

Signed-off-by: Thien Nguyen <nguyentm@ornl.gov>