### PR TITLE
Add missing gates in TNQVM gate util

### DIFF
--- a/tnqvm/base/Gates.hpp
+++ b/tnqvm/base/Gates.hpp
@@ -246,6 +246,61 @@ namespace tnqvm {
     }
 
     template <> 
+    std::vector<std::vector<std::complex<double>>> GetGateMatrix<CommonGates::CZ>() {
+        return 
+        {
+            { 1.0, 0.0, 0.0 , 0.0 },
+            { 0.0, 1.0, 0.0 , 0.0 },
+            { 0.0, 0.0, 1.0 , 0.0 },
+            { 0.0, 0.0, 0.0 , -1.0 }
+        };    
+    }
+    
+    template <> 
+    std::vector<std::vector<std::complex<double>>> GetGateMatrix<CommonGates::CY>() {
+        return 
+        {
+            { 1.0, 0.0, 0.0 , 0.0 },
+            { 0.0, 1.0, 0.0 , 0.0 },
+            { 0.0, 0.0, 0.0, std::complex<double>(0, -1) },
+            { 0.0, 0.0, std::complex<double>(0, 1), 0.0 }
+        };    
+    }
+
+    template <> 
+    std::vector<std::vector<std::complex<double>>> GetGateMatrix<CommonGates::CH>() {
+        return 
+        {
+            { 1.0, 0.0, 0.0 , 0.0 },
+            { 0.0, 1.0, 0.0 , 0.0 },
+            { 0.0, 0.0, M_SQRT1_2, M_SQRT1_2 },
+            { 0.0, 0.0, M_SQRT1_2, -M_SQRT1_2 }
+        };    
+    }
+
+    template <> 
+    std::vector<std::vector<std::complex<double>>> GetGateMatrix<CommonGates::CRZ>(double in_theta) {
+        return 
+        {
+            { 1.0, 0.0, 0.0 , 0.0 },
+            { 0.0, 1.0, 0.0 , 0.0 },
+            { 0.0, 0.0, std::exp(std::complex<double>(0, -0.5 * in_theta)) , 0.0 },
+            { 0.0, 0.0, 0.0 , std::exp(std::complex<double>(0, 0.5 * in_theta)) }
+        };    
+    }
+
+    template <> 
+    std::vector<std::vector<std::complex<double>>> GetGateMatrix<CommonGates::CPhase>(double in_theta) {
+        return 
+        {
+            { 1.0, 0.0, 0.0 , 0.0 },
+            { 0.0, 1.0, 0.0 , 0.0 },
+            { 0.0, 0.0, 1.0 , 0.0 },
+            { 0.0, 0.0, 0.0 , std::exp(std::complex<double>(0, in_theta)) }
+        };    
+    }
+
+    template <> 
     std::vector<std::vector<std::complex<double>>> GetGateMatrix<CommonGates::Swap>() {
         return 
         {

--- a/tnqvm/visitors/exatn-dm/ExaTnDmVisitor.cpp
+++ b/tnqvm/visitors/exatn-dm/ExaTnDmVisitor.cpp
@@ -164,6 +164,18 @@ getGateMatrix(const xacc::Instruction &in_gate, bool in_dagger = false) {
       return GetGateMatrix<CommonGates::Tdg>();
     case CommonGates::CNOT:
       return GetGateMatrix<CommonGates::CNOT>();
+    case CommonGates::CY:
+      return GetGateMatrix<CommonGates::CY>();
+    case CommonGates::CZ:
+      return GetGateMatrix<CommonGates::CZ>();
+    case CommonGates::CH:
+      return GetGateMatrix<CommonGates::CH>();
+    case CommonGates::CRZ:
+      return GetGateMatrix<CommonGates::CRZ>(
+          in_gate.getParameter(0).as<double>());
+    case CommonGates::CPhase:
+      return GetGateMatrix<CommonGates::CPhase>(
+          in_gate.getParameter(0).as<double>());
     case CommonGates::Swap:
       return GetGateMatrix<CommonGates::Swap>();
     case CommonGates::iSwap:

--- a/tnqvm/visitors/exatn-mpo/ExaTnPmpsVisitor.cpp
+++ b/tnqvm/visitors/exatn-mpo/ExaTnPmpsVisitor.cpp
@@ -164,6 +164,16 @@ std::vector<std::complex<double>> getGateMatrix(const xacc::Instruction& in_gate
             case CommonGates::Tdg:
               return GetGateMatrix<CommonGates::Tdg>();
             case CommonGates::CNOT: return GetGateMatrix<CommonGates::CNOT>();
+            case CommonGates::CY:
+              return GetGateMatrix<CommonGates::CY>();
+            case CommonGates::CZ:
+              return GetGateMatrix<CommonGates::CZ>();
+            case CommonGates::CH:
+              return GetGateMatrix<CommonGates::CH>();
+            case CommonGates::CRZ:
+              return GetGateMatrix<CommonGates::CRZ>(in_gate.getParameter(0).as<double>());
+            case CommonGates::CPhase:
+              return GetGateMatrix<CommonGates::CPhase>(in_gate.getParameter(0).as<double>());
             case CommonGates::Swap: return GetGateMatrix<CommonGates::Swap>();
             case CommonGates::iSwap: return GetGateMatrix<CommonGates::iSwap>();
             case CommonGates::fSim: return GetGateMatrix<CommonGates::fSim>(in_gate.getParameter(0).as<double>(), in_gate.getParameter(1).as<double>());

--- a/tnqvm/visitors/exatn-mps/ExatnUtils.cpp
+++ b/tnqvm/visitors/exatn-mps/ExatnUtils.cpp
@@ -65,6 +65,16 @@ GateTensor GateTensorConstructor::getGateTensor(xacc::Instruction& in_gate)
                   in_gate.getParameter(2).as<double>());
             case CommonGates::CNOT:
               return GetGateMatrix<CommonGates::CNOT>();
+            case CommonGates::CY:
+              return GetGateMatrix<CommonGates::CY>();
+            case CommonGates::CZ:
+              return GetGateMatrix<CommonGates::CZ>();
+            case CommonGates::CH:
+              return GetGateMatrix<CommonGates::CH>();
+            case CommonGates::CRZ:
+              return GetGateMatrix<CommonGates::CRZ>(in_gate.getParameter(0).as<double>());
+            case CommonGates::CPhase:
+              return GetGateMatrix<CommonGates::CPhase>(in_gate.getParameter(0).as<double>());
             case CommonGates::Swap: return GetGateMatrix<CommonGates::Swap>();
             case CommonGates::iSwap: return GetGateMatrix<CommonGates::iSwap>();
             case CommonGates::fSim: return GetGateMatrix<CommonGates::fSim>(in_gate.getParameter(0).as<double>(), in_gate.getParameter(1).as<double>());

--- a/tnqvm/visitors/exatn/ExatnVisitor.cpp
+++ b/tnqvm/visitors/exatn/ExatnVisitor.cpp
@@ -920,7 +920,7 @@ void ExatnVisitor<TNQVM_COMPLEX_TYPE>::visit(Tdg &in_TdgGate) {
 template<typename TNQVM_COMPLEX_TYPE>
 void ExatnVisitor<TNQVM_COMPLEX_TYPE>::visit(CPhase &in_CPhaseGate) {
   TNQVM_TELEMETRY_ZONE(__FUNCTION__, __FILE__, __LINE__);
-  appendGateTensor<CommonGates::CPhase>(in_CPhaseGate);
+  appendGateTensor<CommonGates::CPhase>(in_CPhaseGate, in_CPhaseGate.getParameter(0).as<double>());
 }
 
 template<typename TNQVM_COMPLEX_TYPE>

--- a/tnqvm/visitors/exatn/tests/ExatnVisitorInternalTester.cpp
+++ b/tnqvm/visitors/exatn/tests/ExatnVisitorInternalTester.cpp
@@ -269,6 +269,22 @@ TEST(ExatnVisitorInternalTester, testSequentialCollapse)
   EXPECT_TRUE(areAllBitsEqual);
 }
 
+TEST(ExatnVisitorInternalTester, testMissingGates) {
+  auto xasmCompiler = xacc::getCompiler("xasm");
+  // TNQVM assert if gate matrix not found.
+  auto ir = xasmCompiler->compile(R"(__qpu__ void test3(qbit q) {
+    CNOT(q[0], q[1]);
+    CY(q[0], q[2]);
+    CZ(q[0], q[3]);
+    CPhase(q[0], q[4], 1.234);
+  })");
+  auto program = ir->getComposite("test3");
+  std::cout << "HOWDY: \n" << program->toString() << "\n";
+  auto buffer = xacc::qalloc(5);
+  auto qpu = xacc::getAccelerator("tnqvm:exatn");
+  qpu->execute(buffer, program);
+}
+
 int main(int argc, char **argv)
 {
   ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
Some gates were missing in the gate utils. There is an assert for gate lookup. 
We just haven't seen these gates very often.

Possibly related to https://github.com/ORNL-QCI/tnqvm/issues/101
(the file referred to in the bug ticket is a legacy one (unused) but I audited the code and fixed these missing gates)