### PR TITLE
Added missing includes in tests

### DIFF
--- a/tnqvm/visitors/exatn-mpo/tests/ExaTnPmpsTester.cpp
+++ b/tnqvm/visitors/exatn-mpo/tests/ExaTnPmpsTester.cpp
@@ -2,6 +2,7 @@
 #include <gtest/gtest.h>
 #include "xacc.hpp"
 #include "xacc_service.hpp"
+#include <fstream>
 
 namespace {
 std::string getBackendJson() {

--- a/tnqvm/visitors/exatn-mpo/tests/NoiseModelTester.cpp
+++ b/tnqvm/visitors/exatn-mpo/tests/NoiseModelTester.cpp
@@ -2,6 +2,7 @@
 #include <gtest/gtest.h>
 #include "xacc.hpp"
 #include "xacc_service.hpp"
+#include <fstream>
 
 TEST(NoiseModelTester, checkReadout)
 {


### PR DESCRIPTION
`<fstream>` was removed from XACC's `heterogenous.hpp`. 
Forgot to pull the latest XACC.

