### PR TITLE
Update exatn-gen

### DIFF
--- a/examples/exatn_gen/exatn_reconstruct_visitor.cpp
+++ b/examples/exatn_gen/exatn_reconstruct_visitor.cpp
@@ -8,8 +8,12 @@
 int benchmarkExaTnGen1()
 {
  auto accelerator = xacc::getAccelerator("tnqvm",
-                    {{"tnqvm-visitor", "exatn-gen"},
-                     {"reconstruct-layers", 2}});
+                    {{"tnqvm-visitor", "exatn-gen"}
+                    ,{"exatn-buffer-size-gb", 2}
+                    ,{"reconstruct-layers", 4}
+                    ,{"reconstruct-tolerance", 1e-3}
+                    ,{"max-bond-dim", 2}
+                    });
  xacc::qasm(R"(.compiler xasm
                .circuit deuteron_ansatz_h3_2
                .parameters t0, t1
@@ -87,7 +91,7 @@ int main(int argc, char **argv) {
  //xacc::logToFile(true);
  //xacc::setLoggingLevel(2);
  int error_code = 0;
- //if(error_code == 0) error_code = benchmarkExaTnGen1();
+ if(error_code == 0) error_code = benchmarkExaTnGen1();
  if(error_code == 0) error_code = benchmarkExaTnGen2();
  xacc::Finalize();
  return error_code;

--- a/examples/exatn_gen/exatn_reconstruct_visitor.cpp
+++ b/examples/exatn_gen/exatn_reconstruct_visitor.cpp
@@ -1,41 +1,94 @@
 #include "xacc.hpp"
 #include "xacc_service.hpp"
+#include "NoiseModel.hpp"
+#include "Optimizer.hpp"
+#include "xacc_observable.hpp"
+#include "Algorithm.hpp"
+
+int benchmarkExaTnGen1()
+{
+ auto accelerator = xacc::getAccelerator("tnqvm",
+                    {{"tnqvm-visitor", "exatn-gen"},
+                     {"reconstruct-layers", 2}});
+ xacc::qasm(R"(.compiler xasm
+               .circuit deuteron_ansatz_h3_2
+               .parameters t0, t1
+               .qbit q
+               X(q[0]);
+               exp_i_theta(q, t0, {{"pauli", "X0 Y1 - Y0 X1"}});
+               exp_i_theta(q, t1, {{"pauli", "X0 Z1 Y2 - X2 Z1 Y0"}});
+              )");
+ auto ansatz = xacc::getCompiled("deuteron_ansatz_h3_2");
+ auto H_N_3 = xacc::quantum::getObservable("pauli",
+               std::string("5.907 - 2.1433 X0X1 - 2.1433 Y0Y1 + .21829 Z0 - 6.125 Z1 + "
+                           "9.625 - 9.625 Z2 - 3.91 X1 X2 - 3.91 Y1 Y2"));
+ auto optimizer = xacc::getOptimizer("nlopt");
+ auto buffer = xacc::qalloc(3);
+ auto vqe = xacc::getAlgorithm("vqe");
+ vqe->initialize({std::make_pair("ansatz", ansatz),
+                  std::make_pair("observable", H_N_3),
+                  std::make_pair("accelerator", accelerator),
+                  std::make_pair("optimizer", optimizer)});
+ auto energies = vqe->execute(buffer, {0.0684968, 0.17797});
+ buffer->print();
+ std::cout << "Energy = " << energies[0] << " VS correct = " << -2.04482 << "\n";
+ //EXPECT_NEAR(energies[0], -2.04482, 0.1);
+ return 0;
+}
+
+
+int benchmarkExaTnGen2()
+{
+ constexpr int NB_QUBITS = 8;
+ constexpr int NB_ELECTRONS = NB_QUBITS / 2;
+ // Using UCCSD as the base ansatz circuit
+ auto tmp = xacc::getService<xacc::Instruction>("uccsd");
+ auto uccsd = std::dynamic_pointer_cast<xacc::CompositeInstruction>(tmp);
+ uccsd->expand({{"ne", NB_ELECTRONS}, {"nq", NB_QUBITS}});
+ auto provider = xacc::getIRProvider("quantum");
+ for (int i = 0; i < NB_QUBITS; ++i) {
+  uccsd->addInstruction(provider->createInstruction("Measure", i));
+ }
+ std::cout << uccsd->getVariables().size() << "\n";
+ const std::vector<double> params(uccsd->getVariables().size(), 1.0);
+ auto evaled_uccsd = uccsd->operator()(params);
+ std::cout << evaled_uccsd->toString() << "\n";
+ /*
+ auto accelerator_exatn_exact = xacc::getAccelerator("tnqvm",
+      {{"tnqvm-visitor", "exatn:double"}
+    //,{"bitstring", std::vector<int>(NB_QUBITS,-1)}
+      ,{"exatn-buffer-size-gb", 2}
+    //,{"exatn-contract-seq-optimizer", "cotengra"}
+      });
+ auto buffer1 = xacc::qalloc(NB_QUBITS);
+ accelerator_exatn_exact->execute(buffer1, evaled_uccsd);
+ buffer1->print();
+ */
+ constexpr int NB_LAYERS = 8;
+ constexpr double RECONSTRUCTION_TOL = 1e-3;
+ constexpr int MAX_BOND_DIM = 4;
+ auto accelerator_exatn_approx = xacc::getAccelerator("tnqvm",
+      {{"tnqvm-visitor", "exatn-gen"}
+      ,{"exatn-buffer-size-gb", 2}
+      ,{"reconstruct-layers", NB_LAYERS}
+      ,{"reconstruct-tolerance", RECONSTRUCTION_TOL}
+      ,{"max-bond-dim", MAX_BOND_DIM}
+      });
+ auto buffer2 = xacc::qalloc(NB_QUBITS);
+ accelerator_exatn_approx->execute(buffer2, evaled_uccsd);
+ buffer2->print();
+ return 0;
+}
+
 
 int main(int argc, char **argv) {
-  xacc::Initialize();
-  xacc::set_verbose(true);
-  // xacc::logToFile(true);
-  // xacc::setLoggingLevel(2);
-  // Number of qubits
-  constexpr int NB_QUBITS = 4;
-  constexpr int NB_ELECTRONS = NB_QUBITS / 2;
-  // Using UCCSD as the base ansatz circuit
-  auto tmp = xacc::getService<xacc::Instruction>("uccsd");
-  auto uccsd = std::dynamic_pointer_cast<xacc::CompositeInstruction>(tmp);
-  uccsd->expand({{"ne", NB_ELECTRONS}, {"nq", NB_QUBITS}});
-  auto provider = xacc::getIRProvider("quantum");
-  for (int i = 0; i < NB_QUBITS; ++i) {
-    uccsd->addInstruction(provider->createInstruction("Measure", i));
-  }
-  std::cout << uccsd->getVariables().size() << "\n";
-  const std::vector<double> params(uccsd->getVariables().size(), 1.0);
-  auto evaled_uccsd = uccsd->operator()(params);
-  std::cout << evaled_uccsd->toString() << "\n";
-  // Exatn-general visitor parameters:
-  // Number of layers to perform reconstruction
-  constexpr int NB_LAYERS = 10;
-  constexpr double RECONSTRUCTION_TOL = 1e-4;
-  // Max bond dim
-  constexpr int MAX_BOND_DIM = 64;
-  auto accelerator = xacc::getAccelerator(
-      "tnqvm", {{"tnqvm-visitor", "exatn-gen"},
-                {"reconstruct-layers", NB_LAYERS},
-                {"reconstruct-tolerance", RECONSTRUCTION_TOL},
-                {"max-bond-dim", MAX_BOND_DIM}});
-  
-	auto buffer = xacc::qalloc(NB_QUBITS);
-	accelerator->execute(buffer, evaled_uccsd);
-	buffer->print();
-	xacc::Finalize();
-  return 0;
+ xacc::Initialize(argc, argv);
+ xacc::set_verbose(true);
+ //xacc::logToFile(true);
+ //xacc::setLoggingLevel(2);
+ int error_code = 0;
+ //if(error_code == 0) error_code = benchmarkExaTnGen1();
+ if(error_code == 0) error_code = benchmarkExaTnGen2();
+ xacc::Finalize();
+ return error_code;
 }

--- a/examples/sycamore/CMakeLists.txt
+++ b/examples/sycamore/CMakeLists.txt
@@ -29,4 +29,6 @@ add_executable(sycamore_circ_slice_samples sycamore_circ_slice_samples.cpp)
 target_link_libraries(sycamore_circ_slice_samples PRIVATE xacc::xacc tnqvm)
 target_compile_definitions(sycamore_circ_slice_samples PRIVATE RESOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/resources")
 
-
+add_executable(sycamore_circ_approx sycamore_circ_approx.cpp)
+target_link_libraries(sycamore_circ_approx PRIVATE xacc::xacc tnqvm)
+target_compile_definitions(sycamore_circ_approx PRIVATE RESOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/resources")

--- a/examples/sycamore/parse_qflex.py
+++ b/examples/sycamore/parse_qflex.py
@@ -1,5 +1,5 @@
-# This is a utility script which parses qflex input circuit 
-# into XASM kernel. 
+# This is a utility script which parses qflex input circuit
+# into XASM kernel.
 # Note: the qubit index mapping (lattice to linear) is
 # specific to the Sycamore device.
 import os, re
@@ -66,7 +66,7 @@ def parseLine(qflexLine, conjugate):
     xasmSrcLines = []
     line = qflexLine.replace('rz', 'Rz')
     line = line.replace(', ', ',')
-    components = re.split('\s+', line)      
+    components = re.split('\s+', line)
     if len(components) == 4:
         # 1-q gate
         gateName = components[1]
@@ -137,7 +137,7 @@ def parseFile(fileName, nbLayers, conjugateLastLayer):
                 if layerId in gatesPerlayers:
                     gatesPerlayers[layerId].append(line)
                 else:
-                    gatesPerlayers[layerId] = [line]       
+                    gatesPerlayers[layerId] = [line]
             if len(components) == 4:
                 # 1-q gate
                 gateName = components[1]
@@ -196,7 +196,7 @@ def parseFile(fileName, nbLayers, conjugateLastLayer):
 
 # Parse all qFlex files to XASM and save
 for filename in os.listdir('resources'):
-    if filename.endswith('.txt'): 
+    if filename.endswith('.txt'):
         nbLayers = int(re.search('sycamore_53_(.*)_0.txt', filename).group(1))
         xasmSrc = parseFile(filename, nbLayers, False)
         pre, ext = os.path.splitext(filename)
@@ -206,10 +206,10 @@ for filename in os.listdir('resources'):
 
 # Generate debug circuits with the last layer conjugated
 for filename in os.listdir('resources'):
-    if filename.endswith('.txt'): 
+    if filename.endswith('.txt'):
         nbLayers = int(re.search('sycamore_53_(.*)_0.txt', filename).group(1))
         xasmSrc = parseFile(filename, nbLayers, True)
         pre, ext = os.path.splitext(filename)
         xasmFilename = pre + '_Conjugate.xasm'
         with open('resources/' + xasmFilename, 'w') as xasmFile:
-            xasmFile.write(xasmSrc)        
+            xasmFile.write(xasmSrc)

--- a/examples/sycamore/sycamore_circ_approx.cpp
+++ b/examples/sycamore/sycamore_circ_approx.cpp
@@ -1,0 +1,73 @@
+// Approximately evaluates the wave-function of Sycamore-53
+#include "xacc.hpp"
+#include <iostream>
+#include <fstream>
+#include <numeric>
+
+// Initial state:
+const std::vector<int> INITIAL_STATE_BIT_STRING(53, 0);
+
+std::string bitStringVecToString(const std::vector<int>& in_vec)
+{
+ std::stringstream s;
+ for (const auto & bit: in_vec) s << bit;
+ return s.str();
+}
+
+int main(int argc, char **argv)
+{
+ xacc::Initialize();
+ //xacc::set_verbose(true);
+ //xacc::logToFile(true);
+ //xacc::setLoggingLevel(1);
+
+ // Options: 4, 5, 6, 8, 10, 12, 14, 16, 18, 20:
+ const int CIRCUIT_DEPTH = 8;
+
+ // Construct the full path to the XASM source file:
+ const std::string XASM_SRC_FILE = std::string(RESOURCE_DIR) + "/sycamore_53_" + std::to_string(CIRCUIT_DEPTH) + "_0.xasm";
+ // Read XASM source:
+ std::ifstream inFile;
+ inFile.open(XASM_SRC_FILE);
+ std::stringstream strStream;
+ strStream << inFile.rdbuf();
+ const std::string kernelName = "sycamoreCirc";
+ std::string xasmSrcStr = strStream.str();
+ // Construct a unique kernel name::
+ const std::string newKernelName = kernelName + "_" + std::to_string(CIRCUIT_DEPTH);
+ xasmSrcStr.replace(xasmSrcStr.find(kernelName), kernelName.length(), newKernelName);
+
+ // The bitstring to calculate amplitude:
+ // Example: bitstring = 000000000...00
+ const std::vector<int> BIT_STRING(53, -1);
+
+ // ExaTN visitor:
+ // Note:
+ // (1) "exatn" == "exatn:double" uses double (64-bit) type;
+ // (1) "exatn:float" uses float (32-bit) type;
+ constexpr int NB_LAYERS = 4;
+ constexpr double RECONSTRUCTION_TOL = 1e-3;
+ constexpr int MAX_BOND_DIM = 32;
+ auto qpu = xacc::getAccelerator("tnqvm",
+            {std::make_pair("tnqvm-visitor", "exatn-gen")
+          //,std::make_pair("bitstring", BIT_STRING)
+            ,std::make_pair("exatn-buffer-size-gb", 8)
+            ,{"reconstruct-layers", NB_LAYERS}
+            ,{"reconstruct-tolerance", RECONSTRUCTION_TOL}
+            ,{"max-bond-dim", MAX_BOND_DIM}
+          //,std::make_pair("exatn-contract-seq-optimizer", "cotengra")
+            });
+
+ // Allocate a register of 53 qubits
+ auto qubitReg = xacc::qalloc(53);
+
+ // Compile the XASM program
+ auto xasmCompiler = xacc::getCompiler("xasm");
+ auto ir = xasmCompiler->compile(xasmSrcStr, qpu);
+ auto program = ir->getComposites()[0];
+ qpu->execute(qubitReg, program);
+ qubitReg->print();
+
+ xacc::Finalize();
+ return 0;
+}

--- a/tnqvm/TNQVM.cpp
+++ b/tnqvm/TNQVM.cpp
@@ -59,6 +59,8 @@ void TNQVM::execute(
     // Initialize the visitor
     visitor->initialize(buffer, getShotCountOption(options));
     visitor->setKernelName(kernelDecomposed.getBase()->name());
+    xacc::info("Number of instructions: " +
+               std::to_string(kernelDecomposed.getBase()->nInstructions()));
     // Walk the base IR tree, and visit each node
     InstructionIterator it(kernelDecomposed.getBase());
     while (it.hasNext()) {
@@ -114,6 +116,8 @@ void TNQVM::execute(std::shared_ptr<xacc::AcceleratorBuffer> buffer,
   }
 
   // Walk the IR tree, and visit each node
+  xacc::info("Number of instructions: " +
+             std::to_string(kernel->nInstructions()));
   InstructionIterator it(kernel);
   while (it.hasNext()) {
     auto nextInst = it.next();

--- a/tnqvm/visitors/exatn-gen/CMakeLists.txt
+++ b/tnqvm/visitors/exatn-gen/CMakeLists.txt
@@ -53,7 +53,7 @@ if (ExaTN_FOUND)
    endif()
 
    file (GLOB HEADERS *.hpp)
-   file (GLOB SRC ${EXATN_VISITOR_CPP_FILE})
+   file (GLOB SRC ${EXATN_VISITOR_CPP_FILE} ExatnGenActivator.cpp)
 
    usFunctionGetResourceSource(TARGET ${LIBRARY_NAME} OUT SRC)
    usFunctionGenerateBundleInit(TARGET ${LIBRARY_NAME} OUT SRC)

--- a/tnqvm/visitors/exatn-gen/ExatnGenActivator.cpp
+++ b/tnqvm/visitors/exatn-gen/ExatnGenActivator.cpp
@@ -1,0 +1,21 @@
+#include "xacc_plugin.hpp"
+#include "ExatnGenVisitor.hpp"
+using namespace cppmicroservices;
+
+class US_ABI_LOCAL ExatnGenActivator : public BundleActivator {
+public:
+  ExatnGenActivator() {}
+
+  void Start(BundleContext context) {
+    context.RegisterService<tnqvm::TNQVMVisitor>(
+        std::make_shared<tnqvm::DefaultExatnGenVisitor>());
+    context.RegisterService<tnqvm::TNQVMVisitor>(
+        std::make_shared<tnqvm::SinglePrecisionExatnGenVisitor>());
+    context.RegisterService<tnqvm::TNQVMVisitor>(
+        std::make_shared<tnqvm::DoublePrecisionExatnGenVisitor>());
+  }
+
+  void Stop(BundleContext context) {}
+};
+
+CPPMICROSERVICES_EXPORT_BUNDLE_ACTIVATOR(ExatnGenActivator)

--- a/tnqvm/visitors/exatn-gen/ExatnGenVisitor.cpp
+++ b/tnqvm/visitors/exatn-gen/ExatnGenVisitor.cpp
@@ -640,7 +640,7 @@ void ExatnGenVisitor<TNQVM_COMPLEX_TYPE>::reconstructCircuitTensor() {
           if (tensorName != "ROOT") {
             auto tensor = iter->second.getTensor();
             const bool created = exatn::createTensorSync(
-                tensor, exatn::TensorElementType::COMPLEX64);
+                tensor, getExatnElementType());
             assert(created);
             const bool initialized = exatn::initTensorRnd(tensor->getName());
             assert(initialized);

--- a/tnqvm/visitors/exatn-gen/ExatnGenVisitor.cpp
+++ b/tnqvm/visitors/exatn-gen/ExatnGenVisitor.cpp
@@ -257,6 +257,7 @@ void ExatnGenVisitor<TNQVM_COMPLEX_TYPE>::initialize(
   }
   m_reconstructTol = 1e-4;
   m_maxBondDim = 512;
+  m_reconstructionFidelity = 1.0;
   // Default builder: MPS
   m_reconstructBuilder = "MPS";
   if (m_layersReconstruct > 0) {
@@ -367,6 +368,7 @@ void ExatnGenVisitor<TNQVM_COMPLEX_TYPE>::initialize(
 
 template <typename TNQVM_COMPLEX_TYPE>
 void ExatnGenVisitor<TNQVM_COMPLEX_TYPE>::finalize() {
+  m_buffer->addExtraInfo("reconstruction-fidelity", m_reconstructionFidelity);
   // This is a single-circuit execution.
   // Do the evaluation now.
   if (!m_obsTensorOperator && !m_measuredBits.empty()) {
@@ -664,6 +666,7 @@ void ExatnGenVisitor<TNQVM_COMPLEX_TYPE>::reconstructCircuitTensor() {
       ss << "Reconstruction succeeded: Residual norm = " << residual_norm
          << "; Fidelity = " << fidelity;
       xacc::info(ss.str());
+      m_reconstructionFidelity *= fidelity;
     } else {
       xacc::error("Reconstruction FAILED!");
     }

--- a/tnqvm/visitors/exatn-gen/ExatnGenVisitor.cpp
+++ b/tnqvm/visitors/exatn-gen/ExatnGenVisitor.cpp
@@ -704,6 +704,11 @@ void ExatnGenVisitor<TNQVM_COMPLEX_TYPE>::reconstructCircuitTensor() {
         return exatn::duplicateSync(*m_previousOptExpansion);
       }
     }();
+    
+    bool success = exatn::balanceNormalizeNorm2Sync(*target, 1.0, 1.0, false);
+    assert(success);
+    success = exatn::balanceNormalizeNorm2Sync(*approximant, 1.0, 1.0, true);
+    assert(success);
     exatn::TensorNetworkReconstructor reconstructor(target, approximant,
                                                     m_reconstructTol);
     std::cout << "Target: \n";
@@ -713,6 +718,8 @@ void ExatnGenVisitor<TNQVM_COMPLEX_TYPE>::reconstructCircuitTensor() {
     // Run the reconstructor:
     bool reconstructSuccess = exatn::sync();
     assert(reconstructSuccess);
+    //exatn::TensorNetworkReconstructor::resetDebugLevel(1); //debug
+    //reconstructor.resetLearningRate(1.0);
     double residual_norm, fidelity;
     bool reconstructed =
         reconstructor.reconstruct(&residual_norm, &fidelity, true);

--- a/tnqvm/visitors/exatn-gen/ExatnGenVisitor.cpp
+++ b/tnqvm/visitors/exatn-gen/ExatnGenVisitor.cpp
@@ -41,8 +41,9 @@
 #include <chrono>
 #include <functional>
 #include <unordered_set>
-#include "xacc_plugin.hpp"
 #include "IRUtils.hpp"
+#include "base/Gates.hpp"
+#include "utils/GateMatrixAlgebra.hpp"
 
 #ifdef TNQVM_EXATN_USES_MKL_BLAS
 #include <dlfcn.h>
@@ -829,6 +830,4 @@ const double ExatnGenVisitor<TNQVM_COMPLEX_TYPE>::getExpectationValueZ(
   return 0.0;
 }
 } // end namespace tnqvm
-// Register with CppMicroservices
-REGISTER_PLUGIN(tnqvm::DefaultExatnGenVisitor, tnqvm::TNQVMVisitor);
 #endif // TNQVM_HAS_EXATN

--- a/tnqvm/visitors/exatn-gen/ExatnGenVisitor.cpp
+++ b/tnqvm/visitors/exatn-gen/ExatnGenVisitor.cpp
@@ -729,7 +729,7 @@ void ExatnGenVisitor<TNQVM_COMPLEX_TYPE>::reconstructCircuitTensor() {
     // Run the reconstructor:
     bool reconstructSuccess = exatn::sync();
     assert(reconstructSuccess);
-    exatn::TensorNetworkReconstructor::resetDebugLevel(1); //debug
+    // exatn::TensorNetworkReconstructor::resetDebugLevel(1); //debug
     reconstructor.resetLearningRate(1.0);
     double residual_norm, fidelity;
     const auto startOpt = std::chrono::system_clock::now();

--- a/tnqvm/visitors/exatn-gen/ExatnGenVisitor.hpp
+++ b/tnqvm/visitors/exatn-gen/ExatnGenVisitor.hpp
@@ -138,6 +138,7 @@ private:
 private:
   std::shared_ptr<exatn::TensorNetwork> m_qubitNetwork;
   exatn::TensorExpansion m_tensorExpansion;
+  std::shared_ptr<exatn::TensorExpansion> m_previousOptExpansion;
   int m_layersReconstruct;
   double m_reconstructTol;
   int m_layerCounter;
@@ -152,6 +153,7 @@ private:
   std::unordered_map<std::string, size_t> m_compositeNameToComponentId;
   std::shared_ptr<exatn::TensorExpansion> m_evaluatedExpansion;
   double m_reconstructionFidelity;
+  bool m_initReconstructionRandom;
 };
 
 template class ExatnGenVisitor<std::complex<double>>;

--- a/tnqvm/visitors/exatn-gen/ExatnGenVisitor.hpp
+++ b/tnqvm/visitors/exatn-gen/ExatnGenVisitor.hpp
@@ -45,12 +45,11 @@
 #ifdef TNQVM_HAS_EXATN
 #include "TNQVMVisitor.hpp"
 #include "exatn.hpp"
-#include "base/Gates.hpp"
-#include "utils/GateMatrixAlgebra.hpp"
 
 namespace tnqvm {
 enum class ObsOpType { I, X, Y, Z, NA };
-
+// Forward declarations:
+enum class CommonGates: int;
 // Simple struct to identify a concrete quantum gate instance,
 // For example, parametric gates, e.g. Rx(theta), will have an instance for each
 // value of theta that is used to instantiate the gate matrix.

--- a/tnqvm/visitors/exatn-gen/ExatnGenVisitor.hpp
+++ b/tnqvm/visitors/exatn-gen/ExatnGenVisitor.hpp
@@ -151,6 +151,7 @@ private:
   std::shared_ptr<exatn::TensorOperator> m_obsTensorOperator;
   std::unordered_map<std::string, size_t> m_compositeNameToComponentId;
   std::shared_ptr<exatn::TensorExpansion> m_evaluatedExpansion;
+  double m_reconstructionFidelity;
 };
 
 template class ExatnGenVisitor<std::complex<double>>;

--- a/tnqvm/visitors/exatn-gen/ExatnGenVisitor.hpp
+++ b/tnqvm/visitors/exatn-gen/ExatnGenVisitor.hpp
@@ -134,6 +134,11 @@ private:
   exatn::TensorOperator
   constructObsTensorOperator(const std::vector<ObsOpType> &in_obsOps) const;
   void reconstructCircuitTensor();
+  // Compute the wave-function slice or amplitude (if all bits are set):
+  std::vector<TNQVM_COMPLEX_TYPE>
+  computeWaveFuncSlice(const exatn::TensorNetwork &in_tensorNetwork,
+                       const std::vector<int> &in_bitString,
+                       const exatn::ProcessGroup &in_processGroup) const;
 
 private:
   std::shared_ptr<exatn::TensorNetwork> m_qubitNetwork;

--- a/tnqvm/visitors/exatn-gen/tests/CMakeLists.txt
+++ b/tnqvm/visitors/exatn-gen/tests/CMakeLists.txt
@@ -4,3 +4,5 @@ include_directories(${XACC_ROOT}/include/gtest)
 add_executable(ExaTnGenTester ExaTnGenTester.cpp)
 target_link_libraries(ExaTnGenTester PRIVATE ${XACC_ROOT}/lib/libgtest.so ${XACC_ROOT}/lib/libgtest_main.so tnqvm-exatn)
 add_test(NAME ExaTnGenTester COMMAND ExaTnGenTester)
+# Multi-threaded on CADES/CI VM will cause this test to slow down.
+set_tests_properties(ExaTnGenTester PROPERTIES ENVIRONMENT "OMP_NUM_THREADS=1")

--- a/tnqvm/visitors/exatn-gen/tests/ExaTnGenTester.cpp
+++ b/tnqvm/visitors/exatn-gen/tests/ExaTnGenTester.cpp
@@ -6,6 +6,16 @@
 #include "xacc_observable.hpp"
 #include "Algorithm.hpp"
 
+TEST(ExaTnGenTester, checkPrecisionSpecification) {
+  xacc::set_verbose(true);
+  auto accelerator1 =
+      xacc::getAccelerator("tnqvm", {{"tnqvm-visitor", "exatn-gen"}});
+  auto accelerator2 =
+      xacc::getAccelerator("tnqvm", {{"tnqvm-visitor", "exatn-gen:float"}});
+  auto accelerator3 =
+      xacc::getAccelerator("tnqvm", {{"tnqvm-visitor", "exatn-gen:double"}});
+}
+
 TEST(ExaTnGenTester, checkExpVal) {
   xacc::set_verbose(true);
   {

--- a/tnqvm/visitors/exatn-gen/tests/ExaTnGenTester.cpp
+++ b/tnqvm/visitors/exatn-gen/tests/ExaTnGenTester.cpp
@@ -163,27 +163,26 @@ TEST(ExaTnGenTester, checkBitstringAmpl) {
   auto xasmCompiler = xacc::getCompiler("xasm");
   auto ir = xasmCompiler->compile(R"(__qpu__ void test1(qbit q) {
             H(q[0]);
-            for (int i = 0; i < 3; i++) {
+            for (int i = 0; i < 7; i++) {
                 CNOT(q[i], q[i + 1]);
             }
         })");
-  std::vector<int> bitstring(4, -1);
+  std::vector<int> bitstring(8, -1);
   auto program = ir->getComposite("test1");
   auto accelerator =
       xacc::getAccelerator("tnqvm", {{"tnqvm-visitor", "exatn-gen:float"},
                                      {"reconstruct-layers", 2},
                                      {"reconstruct-tolerance", 0.01},
                                      {"bitstring", bitstring}});
-  auto qreg = xacc::qalloc(4);
+  auto qreg = xacc::qalloc(8);
   accelerator->execute(qreg, program);
   qreg->print();
   const auto realAmpl = (*qreg)["amplitude-real-vec"].as<std::vector<double>>();
   const auto imagAmpl = (*qreg)["amplitude-imag-vec"].as<std::vector<double>>();
-  // 4 qubits
-  const int nb_elems = 16;
+  const int nb_elems = 256;
   EXPECT_EQ(realAmpl.size(), nb_elems);
   EXPECT_EQ(imagAmpl.size(), nb_elems);
-  // GHZ: |0000> + |1111>/sqrt(2)
+  // GHZ: |000000> + |111111>/sqrt(2)
   for (size_t i = 0; i < nb_elems; ++i) {
     EXPECT_NEAR(imagAmpl[i], 0.0, 0.1);
     EXPECT_NEAR(realAmpl[i],

--- a/tnqvm/visitors/exatn-gen/tests/ExaTnGenTester.cpp
+++ b/tnqvm/visitors/exatn-gen/tests/ExaTnGenTester.cpp
@@ -126,8 +126,9 @@ TEST(ExaTnGenTester, checkVqeH3) {
       "pauli",
       std::string("5.907 - 2.1433 X0X1 - 2.1433 Y0Y1 + .21829 Z0 - 6.125 Z1 + "
                   "9.625 - 9.625 Z2 - 3.91 X1 X2 - 3.91 Y1 Y2"));
-
-  auto optimizer = xacc::getOptimizer("nlopt");
+  const std::vector<double> initialParams{0.07, 0.2};
+  auto optimizer =
+      xacc::getOptimizer("nlopt", {{"initial-parameters", initialParams}});
 
   xacc::qasm(R"(
         .compiler xasm
@@ -167,6 +168,30 @@ TEST(ExaTnGenTester, checkBitstringAmpl) {
                 CNOT(q[i], q[i + 1]);
             }
         })");
+  std::vector<int> bitstring(8, 0);
+  auto program = ir->getComposite("test1");
+  auto accelerator =
+      xacc::getAccelerator("tnqvm", {{"tnqvm-visitor", "exatn-gen:float"},
+                                     {"reconstruct-layers", 2},
+                                     {"reconstruct-tolerance", 0.01},
+                                     {"bitstring", bitstring}});
+  auto qreg = xacc::qalloc(8);
+  accelerator->execute(qreg, program);
+  qreg->print();
+  const auto realAmpl = (*qreg)["amplitude-real"].as<double>();
+  const auto imagAmpl = (*qreg)["amplitude-imag"].as<double>();
+  EXPECT_NEAR(imagAmpl, 0.0, 0.1);
+  EXPECT_NEAR(realAmpl, 1.0 / std::sqrt(2.0), 0.1);
+}
+
+TEST(ExaTnGenTester, checkWavefunctionSlice) {
+  auto xasmCompiler = xacc::getCompiler("xasm");
+  auto ir = xasmCompiler->compile(R"(__qpu__ void test1(qbit q) {
+            H(q[0]);
+            for (int i = 0; i < 7; i++) {
+                CNOT(q[i], q[i + 1]);
+            }
+        })");
   std::vector<int> bitstring(8, -1);
   auto program = ir->getComposite("test1");
   auto accelerator =
@@ -191,42 +216,42 @@ TEST(ExaTnGenTester, checkBitstringAmpl) {
   }
 }
 
-// TEST(ExaTnGenTester, checkVqeH3Approx) {
-//   // Use very high tolerance to save test time
-//   auto accelerator =
-//       xacc::getAccelerator("tnqvm", {{"tnqvm-visitor", "exatn-gen"},
-//                                      {"reconstruct-layers", 10},
-//                                      {"reconstruct-tolerance", 0.01}});
-//   xacc::set_verbose(true);
-//   xacc::qasm(R"(
-//         .compiler xasm
-//         .circuit deuteron_ansatz_h3_2
-//         .parameters t0, t1
-//         .qbit q
-//         X(q[0]);
-//         exp_i_theta(q, t0, {{"pauli", "X0 Y1 - Y0 X1"}});
-//         exp_i_theta(q, t1, {{"pauli", "X0 Z1 Y2 - X2 Z1 Y0"}});
-//     )");
-//   auto ansatz = xacc::getCompiled("deuteron_ansatz_h3_2");
-//   auto H_N_3 = xacc::quantum::getObservable(
-//       "pauli",
-//       std::string("5.907 - 2.1433 X0X1 - 2.1433 Y0Y1 + .21829 Z0 - 6.125 Z1 + "
-//                   "9.625 - 9.625 Z2 - 3.91 X1 X2 - 3.91 Y1 Y2"));
-//   auto optimizer = xacc::getOptimizer("nlopt");
-//   // Allocate some qubits and execute
-//   auto buffer = xacc::qalloc(3);
-//   auto vqe = xacc::getAlgorithm("vqe");
-//   vqe->initialize({std::make_pair("ansatz", ansatz),
-//                    std::make_pair("observable", H_N_3),
-//                    std::make_pair("accelerator", accelerator),
-//                    std::make_pair("optimizer", optimizer)});
-//   // The reconstruction can take a long time, so we just test a single
-//   // observable evaluation.
-//   auto energies = vqe->execute(buffer, {0.0684968, 0.17797});
-//   buffer->print();
-//   std::cout << "Energy = " << energies[0] << "\n";
-//   EXPECT_NEAR(energies[0], -2.04482, 0.1);
-// }
+TEST(ExaTnGenTester, checkVqeH3Approx) {
+  // Use very high tolerance to save test time
+  auto accelerator =
+      xacc::getAccelerator("tnqvm", {{"tnqvm-visitor", "exatn-gen"},
+                                     {"reconstruct-layers", 4},
+                                     {"reconstruct-tolerance", 0.01}});
+  xacc::set_verbose(true);
+  xacc::qasm(R"(
+        .compiler xasm
+        .circuit deuteron_ansatz_h3_2
+        .parameters t0, t1
+        .qbit q
+        X(q[0]);
+        exp_i_theta(q, t0, {{"pauli", "X0 Y1 - Y0 X1"}});
+        exp_i_theta(q, t1, {{"pauli", "X0 Z1 Y2 - X2 Z1 Y0"}});
+    )");
+  auto ansatz = xacc::getCompiled("deuteron_ansatz_h3_2");
+  auto H_N_3 = xacc::quantum::getObservable(
+      "pauli",
+      std::string("5.907 - 2.1433 X0X1 - 2.1433 Y0Y1 + .21829 Z0 - 6.125 Z1 + "
+                  "9.625 - 9.625 Z2 - 3.91 X1 X2 - 3.91 Y1 Y2"));
+  auto optimizer = xacc::getOptimizer("nlopt");
+  // Allocate some qubits and execute
+  auto buffer = xacc::qalloc(3);
+  auto vqe = xacc::getAlgorithm("vqe");
+  vqe->initialize({std::make_pair("ansatz", ansatz),
+                   std::make_pair("observable", H_N_3),
+                   std::make_pair("accelerator", accelerator),
+                   std::make_pair("optimizer", optimizer)});
+  // The reconstruction can take a long time, so we just test a single
+  // observable evaluation.
+  auto energies = vqe->execute(buffer, {0.0684968, 0.17797});
+  buffer->print();
+  std::cout << "Energy = " << energies[0] << "\n";
+  EXPECT_NEAR(energies[0], -2.04482, 0.1);
+}
 
 int main(int argc, char **argv) {
   xacc::Initialize(argc, argv);


### PR DESCRIPTION
Fixed https://github.com/ORNL-QCI/tnqvm/issues/107

- Use prior tensor expansion as the initial guess.

- Add accumulated fidelity info. 

- Unit test to use 1 thread since it causes long runtime on CI/Cades VM.