### PR TITLE
Fixed MPI-mode MPS visitor deadlock

### DIFF
--- a/tnqvm/visitors/exatn-mps/ExaTnMpsVisitor.cpp
+++ b/tnqvm/visitors/exatn-mps/ExaTnMpsVisitor.cpp
@@ -2105,6 +2105,15 @@ void ExatnMpsVisitor::applyTwoQubitGate(xacc::Instruction& in_gateInstruction)
             const bool postBroadCastOk = exatn::replicateTensorSync(*m_rightSharedProcessGroup, qubitTensorName, 0);
             assert(postBroadCastOk);
         }
+        {
+          unsigned int neighborRank;
+          const bool checkRank =
+              m_rightSharedProcessGroup->rankIsIn(m_rank + 1, &neighborRank);
+          assert(checkRank);
+          const bool dereplicateTensorOk = exatn::dereplicateTensorSync(
+              *m_rightSharedProcessGroup, qubitTensorName, neighborRank);
+          assert(dereplicateTensorOk);
+        }
     }
     else if (indexInRange(qMax, m_qubitRange))
     {
@@ -2135,6 +2144,15 @@ void ExatnMpsVisitor::applyTwoQubitGate(xacc::Instruction& in_gateInstruction)
             assert(postBroadCastOk);
         }
 
+        {
+          unsigned int myLocalRank;
+          const bool checkRank =
+              m_leftSharedProcessGroup->rankIsIn(m_rank, &myLocalRank);
+          assert(checkRank);
+          const bool dereplicateTensorOk = exatn::dereplicateTensorSync(
+              *m_leftSharedProcessGroup, qubitTensorName, myLocalRank);
+          assert(dereplicateTensorOk);
+        }
         // Update the tensor network to take into
         // account the updated tensor.
         rebuildTensorNetwork();

--- a/tnqvm/visitors/exatn-mps/ExaTnMpsVisitor.hpp
+++ b/tnqvm/visitors/exatn-mps/ExaTnMpsVisitor.hpp
@@ -120,7 +120,10 @@ private:
     std::vector<uint8_t> getMeasureSample(const std::vector<size_t>& in_qubitIdx);
     void printStateVec();
     // Truncate the bond dimension between two tensors that are decomposed by SVD
-    void truncateSvdTensors(const std::string& in_leftTensorName, const std::string& in_rightTensorName, double in_eps = std::numeric_limits<double>::min());
+    void truncateSvdTensors(const std::string &in_leftTensorName,
+                            const std::string &in_rightTensorName,
+                            double in_eps = std::numeric_limits<double>::min(),
+                            exatn::ProcessGroup *in_processGroup = nullptr);
     std::vector<std::complex<double>> computeWaveFuncSlice(const exatn::numerics::TensorNetwork& in_tensorNetwork, const std::vector<int>& bitString, const exatn::ProcessGroup& in_processGroup) const;
     double computeStateVectorNorm(const exatn::numerics::TensorNetwork& in_tensorNetwork, const exatn::ProcessGroup& in_processGroup) const;
 


### PR DESCRIPTION
Some operations in the MPS visitor don't conform to the domain of existence.

- Temporary tensors in decompose SVD needs to be created in the local process group.

- Using the new `dereplicateTensor` API to localize MPS tensors after cross-process replication.