### PR TITLE
Enabled execute with basis rotations

### DIFF
--- a/tnqvm/TNQVM.hpp
+++ b/tnqvm/TNQVM.hpp
@@ -132,6 +132,11 @@ public:
   void execute(std::shared_ptr<AcceleratorBuffer> buffer,
                const std::vector<std::shared_ptr<CompositeInstruction>> functions) override;
 
+  virtual void
+  execute(std::shared_ptr<AcceleratorBuffer> buffer,
+          const std::shared_ptr<CompositeInstruction> baseCircuit,
+          const std::vector<std::shared_ptr<CompositeInstruction>> basisRotations) override;
+
   const std::vector<std::complex<double>>
   getAcceleratorState(std::shared_ptr<CompositeInstruction> program) override;
 


### PR DESCRIPTION
This PR enables TNQVM to leverage `Accelerator::execute()` provided a base, state preparation circuit and the single-qubit basis rotations for measurements.