### PR TITLE
Enabled compilation when XACC is built without remote accelerator support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,9 @@ if (EXATN_DIR)
  set(ExaTN_DIR ${EXATN_DIR})
 endif()
 
+# We need this in case XACC is built without support for remote accelerators
+add_compile_definitions(REMOTE_DISABLED)
+
 add_subdirectory(tnqvm)
 
 # Build example programs if enabled


### PR DESCRIPTION
This fixes a bug (a bit of an edge case) where, if XACC is built without remote accelerator support, via `-DXACC_REMOTE_ACCELERATORS=OFF`, the compiler flag `REMOTE_DISABLED` is defined and `RemoteAccelerator.hpp` header is not installed. Since TNQVM includes `xacc.hpp`, without this change, it won't build because it will miss that header. Since TNQVM is not a remote accelerator, it wouldn't ever need this header, so this change ensures we don't run into this problem.